### PR TITLE
feat: get native isPlaying

### DIFF
--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -460,7 +460,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// has been sent to the platform, not when playback itself is totally
   /// finished.
   Future<void> play() async {
-    print('VideoPlayer play called!!!');
     if (value.position == value.duration) {
       await seekTo(Duration.zero);
     }
@@ -477,7 +476,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   /// Pauses the video.
   Future<void> pause() async {
-    print('VideoPlayer pause called!!!');
     value = value.copyWith(isPlaying: false);
     await _applyPlayPause();
   }
@@ -516,7 +514,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       return;
     }
     if (value.isPlaying) {
-      print('_applyPlayPause: play called!!!!');
       await _videoPlayerPlatform.play(_textureId);
 
       // Cancel previous timer.
@@ -541,7 +538,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       await _applyPlaybackSpeed();
     } else {
       _timerForPosition?.cancel();
-      print('_applyPlayPause: pause called!!!!');
       await _videoPlayerPlatform.pause(_textureId);
     }
   }

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -319,10 +319,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   Future<void> initialize() async {
     final bool allowBackgroundPlayback =
         videoPlayerOptions?.allowBackgroundPlayback ?? false;
-    if (allowBackgroundPlayback) {
-      // background時にしか起きない不整合の対応(詳細は_VideoAppLifeCycleObserver内部に)
-      _lifeCycleObserver = _VideoAppLifeCycleObserver(this);
-    }
+    _lifeCycleObserver =
+        _VideoAppLifeCycleObserver(this, allowBackgroundPlayback);
     _lifeCycleObserver?.initialize();
     _creatingCompleter = Completer<void>();
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -746,13 +746,13 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
   Future<void> didChangeAppLifecycleState(AppLifecycleState state) async {
     switch (state) {
       case AppLifecycleState.resumed:
-        // WORKAROUND: iOSで
+        // WORKAROUND:
         // 1. background再生を有効にし、レース詳細の映像を再生したままbackgroundへ
         // 2. 他のアプリで動画や音声を再生する
         // 3. WTに戻ってきたときに動画自体は停止しているのにvalue.isPlayingがtrueのままになっている
         // そのため最新のisPlayingの値を取得する
         final bool? isPlaying = await _controller.isPlaying;
-        if (isPlaying != null && defaultTargetPlatform == TargetPlatform.iOS) {
+        if (isPlaying != null) {
           isPlaying ? _controller.play() : _controller.pause();
         }
         break;

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -747,9 +747,9 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
     switch (state) {
       case AppLifecycleState.resumed:
         // WORKAROUND:
-        // 1. background再生を有効にし、レース詳細の映像を再生したままbackgroundへ
+        // 1. background再生を有効時に映像を再生したままbackgroundへ
         // 2. 他のアプリで動画や音声を再生する
-        // 3. WTに戻ってきたときに動画自体は停止しているのにvalue.isPlayingがtrueのままになっている
+        // 3. 本アプリに戻ってきたときに動画自体は停止しているのにvalue.isPlayingがtrueのままになっている
         // そのため最新のisPlayingの値を取得する
         final bool? isPlaying = await _controller.isPlaying;
         if (isPlaying == null) return;

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -752,22 +752,11 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
         // 3. WTに戻ってきたときに動画自体は停止しているのにvalue.isPlayingがtrueのままになっている
         // そのため最新のisPlayingの値を取得する
         final bool? isPlaying = await _controller.isPlaying;
-        if (isPlaying != null) {
-          isPlaying ? _controller.play() : _controller.pause();
-        }
+        if (isPlaying == null) return;
+        isPlaying ? _controller.play() : _controller.pause();
         break;
       default:
     }
-    // WARNING: 元々の_wasPlayingBeforePauseの実装に関してはapp側で実装をおこなっておりvideo_player側の実装からは外す。
-    // SeeAlso: https://github.com/WinTicket/plugins/blob/ff84c44a5ddbfe10e96f16fe6c09157d36cc2867/packages/video_player/video_player/lib/video_player.dart#L699
-    // if (state == AppLifecycleState.paused) {
-    //   _wasPlayingBeforePause = _controller.value.isPlaying;
-    //   _controller.pause();
-    // } else if (state == AppLifecycleState.resumed) {
-    //   if (_wasPlayingBeforePause) {
-    //     _controller.play();
-    //   }
-    // }
   }
 
   void dispose() {

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -583,10 +583,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     return await _videoPlayerPlatform.getDuration(_textureId);
   }
 
-  /// The latest playing status.
-  Future<bool?> get isPlaying async {
+  /// Get latest isPlaying status from ExoPlayer/AVPlayer
+  Future<bool> get isPlaying async {
     if (_isDisposed) {
-      return null;
+      return false;
     }
     return await _videoPlayerPlatform.getIsPlaying(_textureId);
   }

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -82,6 +82,12 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
   Future<void> setClosedCaptionFile(
     Future<ClosedCaptionFile>? closedCaptionFile,
   ) async {}
+
+  @override
+  Future<bool?> get isPlaying async => value.isPlaying;
+
+  @override
+  Future<void> setBuffer(Buffer buffer) async {}
 }
 
 Future<ClosedCaptionFile> _loadClosedCaption() async =>

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -556,6 +556,62 @@ public class Messages {
       return pigeonResult;
     }
   }
+
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class IsPlayingMessage {
+    private @NonNull Long textureId;
+    public @NonNull Long getTextureId() { return textureId; }
+    public void setTextureId(@NonNull Long setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"textureId\" is null.");
+      }
+      this.textureId = setterArg;
+    }
+
+    private @NonNull Boolean isPlaying;
+    public @NonNull Boolean getIsPlaying() { return isPlaying; }
+    public void setIsPlaying(@NonNull Boolean setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"isPlaying\" is null.");
+      }
+      this.isPlaying = setterArg;
+    }
+
+    /** Constructor is private to enforce null safety; use Builder. */
+    private IsPlayingMessage() {}
+    public static final class Builder {
+      private @Nullable Long textureId;
+      public @NonNull Builder setTextureId(@NonNull Long setterArg) {
+        this.textureId = setterArg;
+        return this;
+      }
+      private @Nullable Boolean isPlaying;
+      public @NonNull Builder setIsPlaying(@NonNull Boolean setterArg) {
+        this.isPlaying = setterArg;
+        return this;
+      }
+      public @NonNull IsPlayingMessage build() {
+        IsPlayingMessage pigeonReturn = new IsPlayingMessage();
+        pigeonReturn.setTextureId(textureId);
+        pigeonReturn.setIsPlaying(isPlaying);
+        return pigeonReturn;
+      }
+    }
+    @NonNull Map<String, Object> toMap() {
+      Map<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("textureId", textureId);
+      toMapResult.put("isPlaying", isPlaying);
+      return toMapResult;
+    }
+    static @NonNull IsPlayingMessage fromMap(@NonNull Map<String, Object> map) {
+      IsPlayingMessage pigeonResult = new IsPlayingMessage();
+      Object textureId = map.get("textureId");
+      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer)textureId : (Long)textureId));
+      Object isPlaying = map.get("isPlaying");
+      pigeonResult.setIsPlaying((Boolean)isPlaying);
+      return pigeonResult;
+    }
+  }
   private static class AndroidVideoPlayerApiCodec extends StandardMessageCodec {
     public static final AndroidVideoPlayerApiCodec INSTANCE = new AndroidVideoPlayerApiCodec();
     private AndroidVideoPlayerApiCodec() {}
@@ -572,21 +628,24 @@ public class Messages {
           return DurationMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)131:         
-          return LoopingMessage.fromMap((Map<String, Object>) readValue(buffer));
+          return IsPlayingMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)132:         
-          return MixWithOthersMessage.fromMap((Map<String, Object>) readValue(buffer));
+          return LoopingMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)133:         
-          return PlaybackSpeedMessage.fromMap((Map<String, Object>) readValue(buffer));
+          return MixWithOthersMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)134:         
-          return PositionMessage.fromMap((Map<String, Object>) readValue(buffer));
+          return PlaybackSpeedMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)135:         
-          return TextureMessage.fromMap((Map<String, Object>) readValue(buffer));
+          return PositionMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)136:         
+          return TextureMessage.fromMap((Map<String, Object>) readValue(buffer));
+        
+        case (byte)137:         
           return VolumeMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         default:        
@@ -608,28 +667,32 @@ public class Messages {
         stream.write(130);
         writeValue(stream, ((DurationMessage) value).toMap());
       } else 
-      if (value instanceof LoopingMessage) {
+      if (value instanceof IsPlayingMessage) {
         stream.write(131);
+        writeValue(stream, ((IsPlayingMessage) value).toMap());
+      } else 
+      if (value instanceof LoopingMessage) {
+        stream.write(132);
         writeValue(stream, ((LoopingMessage) value).toMap());
       } else 
       if (value instanceof MixWithOthersMessage) {
-        stream.write(132);
+        stream.write(133);
         writeValue(stream, ((MixWithOthersMessage) value).toMap());
       } else 
       if (value instanceof PlaybackSpeedMessage) {
-        stream.write(133);
+        stream.write(134);
         writeValue(stream, ((PlaybackSpeedMessage) value).toMap());
       } else 
       if (value instanceof PositionMessage) {
-        stream.write(134);
+        stream.write(135);
         writeValue(stream, ((PositionMessage) value).toMap());
       } else 
       if (value instanceof TextureMessage) {
-        stream.write(135);
+        stream.write(136);
         writeValue(stream, ((TextureMessage) value).toMap());
       } else 
       if (value instanceof VolumeMessage) {
-        stream.write(136);
+        stream.write(137);
         writeValue(stream, ((VolumeMessage) value).toMap());
       } else 
 {
@@ -653,6 +716,7 @@ public class Messages {
     void pause(@NonNull TextureMessage msg);
     void setMixWithOthers(@NonNull MixWithOthersMessage msg);
     void setBuffer(@NonNull BufferMessage msg);
+    @NonNull IsPlayingMessage isPlaying(@NonNull TextureMessage msg);
 
     /** The codec used by AndroidVideoPlayerApi. */
     static MessageCodec<Object> getCodec() {
@@ -958,6 +1022,30 @@ public class Messages {
               }
               api.setBuffer(msgArg);
               wrapped.put("result", null);
+            }
+            catch (Error | RuntimeException exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AndroidVideoPlayerApi.isPlaying", getCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            Map<String, Object> wrapped = new HashMap<>();
+            try {
+              ArrayList<Object> args = (ArrayList<Object>)message;
+              TextureMessage msgArg = (TextureMessage)args.get(0);
+              if (msgArg == null) {
+                throw new NullPointerException("msgArg unexpectedly null.");
+              }
+              IsPlayingMessage output = api.isPlaying(msgArg);
+              wrapped.put("result", output);
             }
             catch (Error | RuntimeException exception) {
               wrapped.put("error", wrapError(exception));

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -309,7 +309,7 @@ final class VideoPlayer {
     return exoPlayer.getDuration();
   }
 
-  long getIsPlaying() { return exoPlayer.getPlaybackState() == Player.STATE_READY && exoPlayer.getPlayWhenReady(); }
+  boolean getIsPlaying() { return exoPlayer.isPlaying(); }
 
   @SuppressWarnings("SuspiciousNameCombination")
   @VisibleForTesting

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -309,6 +309,8 @@ final class VideoPlayer {
     return exoPlayer.getDuration();
   }
 
+  long getIsPlaying() { return exoPlayer.getPlaybackState() == Player.STATE_READY && exoPlayer.getPlayWhenReady(); }
+
   @SuppressWarnings("SuspiciousNameCombination")
   @VisibleForTesting
   void sendInitialized() {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -16,6 +16,7 @@ import io.flutter.plugins.videoplayer.Messages.AndroidVideoPlayerApi;
 import io.flutter.plugins.videoplayer.Messages.BufferMessage;
 import io.flutter.plugins.videoplayer.Messages.CreateMessage;
 import io.flutter.plugins.videoplayer.Messages.DurationMessage;
+import io.flutter.plugins.videoplayer.Messages.IsPlayingMessage;
 import io.flutter.plugins.videoplayer.Messages.LoopingMessage;
 import io.flutter.plugins.videoplayer.Messages.MixWithOthersMessage;
 import io.flutter.plugins.videoplayer.Messages.PlaybackSpeedMessage;
@@ -209,6 +210,17 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
                 .setDuration(player.getDuration())
                 .setTextureId(arg.getTextureId())
                 .build();
+    player.sendBufferingUpdate();
+    return result;
+  }
+
+  public IsPlayingMessage isPlaying(TextureMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    IsPlayingMessage result =
+            new IsPlayingMessage.Builder()
+                    .setIsPlaying(player.getIsPlaying())
+                    .setTextureId(arg.getTextureId())
+                    .build();
     player.sendBufferingUpdate();
     return result;
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -221,7 +221,6 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
                     .setIsPlaying(player.getIsPlaying())
                     .setTextureId(arg.getTextureId())
                     .build();
-    player.sendBufferingUpdate();
     return result;
   }
 

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -125,6 +125,13 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
+  Future<bool> getIsPlaying(int textureId) async {
+    final IsPlayingMessage response =
+        await _api.isPlaying(TextureMessage(textureId: textureId));
+    return response.isPlaying;
+  }
+
+  @override
   Stream<VideoEvent> videoEventsFor(int textureId) {
     return _eventChannelFor(textureId)
         .receiveBroadcastStream()

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -248,6 +248,31 @@ class BufferMessage {
   }
 }
 
+class IsPlayingMessage {
+  IsPlayingMessage({
+    required this.textureId,
+    required this.isPlaying,
+  });
+
+  int textureId;
+  bool isPlaying;
+
+  Object encode() {
+    final Map<Object?, Object?> pigeonMap = <Object?, Object?>{};
+    pigeonMap['textureId'] = textureId;
+    pigeonMap['isPlaying'] = isPlaying;
+    return pigeonMap;
+  }
+
+  static IsPlayingMessage decode(Object message) {
+    final Map<Object?, Object?> pigeonMap = message as Map<Object?, Object?>;
+    return IsPlayingMessage(
+      textureId: pigeonMap['textureId']! as int,
+      isPlaying: pigeonMap['isPlaying']! as bool,
+    );
+  }
+}
+
 class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
   const _AndroidVideoPlayerApiCodec();
   @override
@@ -264,28 +289,32 @@ class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
     } else 
-    if (value is LoopingMessage) {
+    if (value is IsPlayingMessage) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
     } else 
-    if (value is MixWithOthersMessage) {
+    if (value is LoopingMessage) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PlaybackSpeedMessage) {
+    if (value is MixWithOthersMessage) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PositionMessage) {
+    if (value is PlaybackSpeedMessage) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else 
-    if (value is TextureMessage) {
+    if (value is PositionMessage) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else 
-    if (value is VolumeMessage) {
+    if (value is TextureMessage) {
       buffer.putUint8(136);
+      writeValue(buffer, value.encode());
+    } else 
+    if (value is VolumeMessage) {
+      buffer.putUint8(137);
       writeValue(buffer, value.encode());
     } else 
 {
@@ -305,21 +334,24 @@ class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
         return DurationMessage.decode(readValue(buffer)!);
       
       case 131:       
-        return LoopingMessage.decode(readValue(buffer)!);
+        return IsPlayingMessage.decode(readValue(buffer)!);
       
       case 132:       
-        return MixWithOthersMessage.decode(readValue(buffer)!);
+        return LoopingMessage.decode(readValue(buffer)!);
       
       case 133:       
-        return PlaybackSpeedMessage.decode(readValue(buffer)!);
+        return MixWithOthersMessage.decode(readValue(buffer)!);
       
       case 134:       
-        return PositionMessage.decode(readValue(buffer)!);
+        return PlaybackSpeedMessage.decode(readValue(buffer)!);
       
       case 135:       
-        return TextureMessage.decode(readValue(buffer)!);
+        return PositionMessage.decode(readValue(buffer)!);
       
       case 136:       
+        return TextureMessage.decode(readValue(buffer)!);
+      
+      case 137:       
         return VolumeMessage.decode(readValue(buffer)!);
       
       default:      
@@ -637,6 +669,33 @@ class AndroidVideoPlayerApi {
       );
     } else {
       return;
+    }
+  }
+
+  Future<IsPlayingMessage> isPlaying(TextureMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.AndroidVideoPlayerApi.isPlaying', codec, binaryMessenger: _binaryMessenger);
+    final Map<Object?, Object?>? replyMap =
+        await channel.send(<Object?>[arg_msg]) as Map<Object?, Object?>?;
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyMap['error'] != null) {
+      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      throw PlatformException(
+        code: (error['code'] as String?)!,
+        message: error['message'] as String?,
+        details: error['details'],
+      );
+    } else if (replyMap['result'] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyMap['result'] as IsPlayingMessage?)!;
     }
   }
 }

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -69,6 +69,12 @@ class BufferMessage {
   int? bufferForPlaybackAfterRebufferMs;
 }
 
+class IsPlayingMessage {
+  IsPlayingMessage(this.textureId, this.isPlaying);
+  int textureId;
+  bool isPlaying;
+}
+
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')
 abstract class AndroidVideoPlayerApi {
   void initialize();
@@ -84,4 +90,5 @@ abstract class AndroidVideoPlayerApi {
   void pause(TextureMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
   void setBuffer(BufferMessage msg);
+  IsPlayingMessage isPlaying(TextureMessage msg);
 }

--- a/packages/video_player/video_player_android/test/test_api.dart
+++ b/packages/video_player/video_player_android/test/test_api.dart
@@ -30,28 +30,32 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
     } else 
-    if (value is LoopingMessage) {
+    if (value is IsPlayingMessage) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
     } else 
-    if (value is MixWithOthersMessage) {
+    if (value is LoopingMessage) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PlaybackSpeedMessage) {
+    if (value is MixWithOthersMessage) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PositionMessage) {
+    if (value is PlaybackSpeedMessage) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else 
-    if (value is TextureMessage) {
+    if (value is PositionMessage) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else 
-    if (value is VolumeMessage) {
+    if (value is TextureMessage) {
       buffer.putUint8(136);
+      writeValue(buffer, value.encode());
+    } else 
+    if (value is VolumeMessage) {
+      buffer.putUint8(137);
       writeValue(buffer, value.encode());
     } else 
 {
@@ -71,21 +75,24 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
         return DurationMessage.decode(readValue(buffer)!);
       
       case 131:       
-        return LoopingMessage.decode(readValue(buffer)!);
+        return IsPlayingMessage.decode(readValue(buffer)!);
       
       case 132:       
-        return MixWithOthersMessage.decode(readValue(buffer)!);
+        return LoopingMessage.decode(readValue(buffer)!);
       
       case 133:       
-        return PlaybackSpeedMessage.decode(readValue(buffer)!);
+        return MixWithOthersMessage.decode(readValue(buffer)!);
       
       case 134:       
-        return PositionMessage.decode(readValue(buffer)!);
+        return PlaybackSpeedMessage.decode(readValue(buffer)!);
       
       case 135:       
-        return TextureMessage.decode(readValue(buffer)!);
+        return PositionMessage.decode(readValue(buffer)!);
       
       case 136:       
+        return TextureMessage.decode(readValue(buffer)!);
+      
+      case 137:       
         return VolumeMessage.decode(readValue(buffer)!);
       
       default:      
@@ -110,6 +117,7 @@ abstract class TestHostVideoPlayerApi {
   void pause(TextureMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
   void setBuffer(BufferMessage msg);
+  IsPlayingMessage isPlaying(TextureMessage msg);
   static void setup(TestHostVideoPlayerApi? api, {BinaryMessenger? binaryMessenger}) {
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
@@ -313,6 +321,22 @@ abstract class TestHostVideoPlayerApi {
           assert(arg_msg != null, 'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.setBuffer was null, expected non-null BufferMessage.');
           api.setBuffer(arg_msg!);
           return <Object?, Object?>{};
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.AndroidVideoPlayerApi.isPlaying', codec, binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMockMessageHandler(null);
+      } else {
+        channel.setMockMessageHandler((Object? message) async {
+          assert(message != null, 'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.isPlaying was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final TextureMessage? arg_msg = (args[0] as TextureMessage?);
+          assert(arg_msg != null, 'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.isPlaying was null, expected non-null TextureMessage.');
+          final IsPlayingMessage output = api.isPlaying(arg_msg!);
+          return <Object?, Object?>{'result': output};
         });
       }
     }

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -381,6 +381,10 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   return FLTCMTimeToMillis([_player currentTime]);
 }
 
+- (BOOL)getLatestIsPlaying {
+  return _player.rate > 0;
+}
+
 - (int64_t)duration {
   // AndroidのDurationはライブ配信と過去動画でいい感じに数字を返してくれるが
   // iOSでは
@@ -679,6 +683,13 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   } else {
     [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
   }
+}
+
+- (FLTIsPlayingMessage *)isPlaying:(FLTTextureMessage *)input error:(FlutterError **)error {
+  FLTVideoPlayer *player = self.playersByTextureId[input.textureId];
+  FLTIsPlayingMessage *result = [FLTIsPlayingMessage makeWithTextureId:input.textureId
+                                                            isPlaying:@([player getLatestIsPlaying])];
+  return result;
 }
 
 @end

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class FLTStartMessage;
 @class FLTCreateMessage;
 @class FLTMixWithOthersMessage;
+@class FLTIsPlayingMessage;
 
 @interface FLTTextureMessage : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
@@ -104,6 +105,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) NSNumber * mixWithOthers;
 @end
 
+@interface FLTIsPlayingMessage : NSObject
+/// `init` unavailable to enforce nonnull fields, see the `make` class method.
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)makeWithTextureId:(NSNumber *)textureId
+    isPlaying:(NSNumber *)isPlaying;
+@property(nonatomic, strong) NSNumber * textureId;
+@property(nonatomic, strong) NSNumber * isPlaying;
+@end
+
 /// The codec used by FLTAVFoundationVideoPlayerApi.
 NSObject<FlutterMessageCodec> *FLTAVFoundationVideoPlayerApiGetCodec(void);
 
@@ -125,6 +135,8 @@ NSObject<FlutterMessageCodec> *FLTAVFoundationVideoPlayerApiGetCodec(void);
 - (void)seekTo:(FLTPositionMessage *)msg completion:(void(^)(FlutterError *_Nullable))completion;
 - (void)pause:(FLTTextureMessage *)msg error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)setMixWithOthers:(FLTMixWithOthersMessage *)msg error:(FlutterError *_Nullable *_Nonnull)error;
+/// @return `nil` only when `error != nil`.
+- (nullable FLTIsPlayingMessage *)isPlaying:(FLTTextureMessage *)msg error:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
 extern void FLTAVFoundationVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FLTAVFoundationVideoPlayerApi> *_Nullable api);

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
@@ -70,6 +70,10 @@ static id GetNullableObjectAtIndex(NSArray* array, NSInteger key) {
 + (FLTMixWithOthersMessage *)fromMap:(NSDictionary *)dict;
 - (NSDictionary *)toMap;
 @end
+@interface FLTIsPlayingMessage ()
++ (FLTIsPlayingMessage *)fromMap:(NSDictionary *)dict;
+- (NSDictionary *)toMap;
+@end
 
 @implementation FLTTextureMessage
 + (instancetype)makeWithTextureId:(NSNumber *)textureId {
@@ -260,6 +264,27 @@ static id GetNullableObjectAtIndex(NSArray* array, NSInteger key) {
 }
 @end
 
+@implementation FLTIsPlayingMessage
++ (instancetype)makeWithTextureId:(NSNumber *)textureId
+    isPlaying:(NSNumber *)isPlaying {
+  FLTIsPlayingMessage* pigeonResult = [[FLTIsPlayingMessage alloc] init];
+  pigeonResult.textureId = textureId;
+  pigeonResult.isPlaying = isPlaying;
+  return pigeonResult;
+}
++ (FLTIsPlayingMessage *)fromMap:(NSDictionary *)dict {
+  FLTIsPlayingMessage *pigeonResult = [[FLTIsPlayingMessage alloc] init];
+  pigeonResult.textureId = GetNullableObject(dict, @"textureId");
+  NSAssert(pigeonResult.textureId != nil, @"");
+  pigeonResult.isPlaying = GetNullableObject(dict, @"isPlaying");
+  NSAssert(pigeonResult.isPlaying != nil, @"");
+  return pigeonResult;
+}
+- (NSDictionary *)toMap {
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId", (self.isPlaying ? self.isPlaying : [NSNull null]), @"isPlaying", nil];
+}
+@end
+
 @interface FLTAVFoundationVideoPlayerApiCodecReader : FlutterStandardReader
 @end
 @implementation FLTAVFoundationVideoPlayerApiCodecReader
@@ -273,24 +298,27 @@ static id GetNullableObjectAtIndex(NSArray* array, NSInteger key) {
       return [FLTDurationMessage fromMap:[self readValue]];
     
     case 130:     
-      return [FLTLoopingMessage fromMap:[self readValue]];
+      return [FLTIsPlayingMessage fromMap:[self readValue]];
     
     case 131:     
-      return [FLTMixWithOthersMessage fromMap:[self readValue]];
+      return [FLTLoopingMessage fromMap:[self readValue]];
     
     case 132:     
-      return [FLTPlaybackSpeedMessage fromMap:[self readValue]];
+      return [FLTMixWithOthersMessage fromMap:[self readValue]];
     
     case 133:     
-      return [FLTPositionMessage fromMap:[self readValue]];
+      return [FLTPlaybackSpeedMessage fromMap:[self readValue]];
     
     case 134:     
-      return [FLTStartMessage fromMap:[self readValue]];
+      return [FLTPositionMessage fromMap:[self readValue]];
     
     case 135:     
-      return [FLTTextureMessage fromMap:[self readValue]];
+      return [FLTStartMessage fromMap:[self readValue]];
     
     case 136:     
+      return [FLTTextureMessage fromMap:[self readValue]];
+    
+    case 137:     
       return [FLTVolumeMessage fromMap:[self readValue]];
     
     default:    
@@ -313,32 +341,36 @@ static id GetNullableObjectAtIndex(NSArray* array, NSInteger key) {
     [self writeByte:129];
     [self writeValue:[value toMap]];
   } else 
-  if ([value isKindOfClass:[FLTLoopingMessage class]]) {
+  if ([value isKindOfClass:[FLTIsPlayingMessage class]]) {
     [self writeByte:130];
     [self writeValue:[value toMap]];
   } else 
-  if ([value isKindOfClass:[FLTMixWithOthersMessage class]]) {
+  if ([value isKindOfClass:[FLTLoopingMessage class]]) {
     [self writeByte:131];
     [self writeValue:[value toMap]];
   } else 
-  if ([value isKindOfClass:[FLTPlaybackSpeedMessage class]]) {
+  if ([value isKindOfClass:[FLTMixWithOthersMessage class]]) {
     [self writeByte:132];
     [self writeValue:[value toMap]];
   } else 
-  if ([value isKindOfClass:[FLTPositionMessage class]]) {
+  if ([value isKindOfClass:[FLTPlaybackSpeedMessage class]]) {
     [self writeByte:133];
     [self writeValue:[value toMap]];
   } else 
-  if ([value isKindOfClass:[FLTStartMessage class]]) {
+  if ([value isKindOfClass:[FLTPositionMessage class]]) {
     [self writeByte:134];
     [self writeValue:[value toMap]];
   } else 
-  if ([value isKindOfClass:[FLTTextureMessage class]]) {
+  if ([value isKindOfClass:[FLTStartMessage class]]) {
     [self writeByte:135];
     [self writeValue:[value toMap]];
   } else 
-  if ([value isKindOfClass:[FLTVolumeMessage class]]) {
+  if ([value isKindOfClass:[FLTTextureMessage class]]) {
     [self writeByte:136];
+    [self writeValue:[value toMap]];
+  } else 
+  if ([value isKindOfClass:[FLTVolumeMessage class]]) {
+    [self writeByte:137];
     [self writeValue:[value toMap]];
   } else 
 {
@@ -622,6 +654,26 @@ void FLTAVFoundationVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMesseng
         FlutterError *error;
         [api setMixWithOthers:arg_msg error:&error];
         callback(wrapResult(nil, error));
+      }];
+    }
+    else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:@"dev.flutter.pigeon.AVFoundationVideoPlayerApi.isPlaying"
+        binaryMessenger:binaryMessenger
+        codec:FLTAVFoundationVideoPlayerApiGetCodec()        ];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(isPlaying:error:)], @"FLTAVFoundationVideoPlayerApi api (%@) doesn't respond to @selector(isPlaying:error:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        NSArray *args = message;
+        FLTTextureMessage *arg_msg = GetNullableObjectAtIndex(args, 0);
+        FlutterError *error;
+        FLTIsPlayingMessage *output = [api isPlaying:arg_msg error:&error];
+        callback(wrapResult(output, error));
       }];
     }
     else {

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -182,6 +182,13 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
     return Future.value();
   }
 
+  @override
+  Future<bool> getIsPlaying(int textureId) async {
+    final IsPlayingMessage isPlayingResponse =
+        await _api.isPlaying(TextureMessage(textureId: textureId));
+    return isPlayingResponse.isPlaying;
+  }
+
   EventChannel _eventChannelFor(int textureId) {
     return EventChannel('flutter.io/videoPlayer/videoEvents$textureId');
   }

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -240,6 +240,31 @@ class MixWithOthersMessage {
   }
 }
 
+class IsPlayingMessage {
+  IsPlayingMessage({
+    required this.textureId,
+    required this.isPlaying,
+  });
+
+  int textureId;
+  bool isPlaying;
+
+  Object encode() {
+    final Map<Object?, Object?> pigeonMap = <Object?, Object?>{};
+    pigeonMap['textureId'] = textureId;
+    pigeonMap['isPlaying'] = isPlaying;
+    return pigeonMap;
+  }
+
+  static IsPlayingMessage decode(Object message) {
+    final Map<Object?, Object?> pigeonMap = message as Map<Object?, Object?>;
+    return IsPlayingMessage(
+      textureId: pigeonMap['textureId']! as int,
+      isPlaying: pigeonMap['isPlaying']! as bool,
+    );
+  }
+}
+
 class _AVFoundationVideoPlayerApiCodec extends StandardMessageCodec {
   const _AVFoundationVideoPlayerApiCodec();
   @override
@@ -252,32 +277,36 @@ class _AVFoundationVideoPlayerApiCodec extends StandardMessageCodec {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
     } else 
-    if (value is LoopingMessage) {
+    if (value is IsPlayingMessage) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
     } else 
-    if (value is MixWithOthersMessage) {
+    if (value is LoopingMessage) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PlaybackSpeedMessage) {
+    if (value is MixWithOthersMessage) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PositionMessage) {
+    if (value is PlaybackSpeedMessage) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
     } else 
-    if (value is StartMessage) {
+    if (value is PositionMessage) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else 
-    if (value is TextureMessage) {
+    if (value is StartMessage) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else 
-    if (value is VolumeMessage) {
+    if (value is TextureMessage) {
       buffer.putUint8(136);
+      writeValue(buffer, value.encode());
+    } else 
+    if (value is VolumeMessage) {
+      buffer.putUint8(137);
       writeValue(buffer, value.encode());
     } else 
 {
@@ -294,24 +323,27 @@ class _AVFoundationVideoPlayerApiCodec extends StandardMessageCodec {
         return DurationMessage.decode(readValue(buffer)!);
       
       case 130:       
-        return LoopingMessage.decode(readValue(buffer)!);
+        return IsPlayingMessage.decode(readValue(buffer)!);
       
       case 131:       
-        return MixWithOthersMessage.decode(readValue(buffer)!);
+        return LoopingMessage.decode(readValue(buffer)!);
       
       case 132:       
-        return PlaybackSpeedMessage.decode(readValue(buffer)!);
+        return MixWithOthersMessage.decode(readValue(buffer)!);
       
       case 133:       
-        return PositionMessage.decode(readValue(buffer)!);
+        return PlaybackSpeedMessage.decode(readValue(buffer)!);
       
       case 134:       
-        return StartMessage.decode(readValue(buffer)!);
+        return PositionMessage.decode(readValue(buffer)!);
       
       case 135:       
-        return TextureMessage.decode(readValue(buffer)!);
+        return StartMessage.decode(readValue(buffer)!);
       
       case 136:       
+        return TextureMessage.decode(readValue(buffer)!);
+      
+      case 137:       
         return VolumeMessage.decode(readValue(buffer)!);
       
       default:      
@@ -634,6 +666,33 @@ class AVFoundationVideoPlayerApi {
       );
     } else {
       return;
+    }
+  }
+
+  Future<IsPlayingMessage> isPlaying(TextureMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.AVFoundationVideoPlayerApi.isPlaying', codec, binaryMessenger: _binaryMessenger);
+    final Map<Object?, Object?>? replyMap =
+        await channel.send(<Object?>[arg_msg]) as Map<Object?, Object?>?;
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyMap['error'] != null) {
+      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      throw PlatformException(
+        code: (error['code'] as String?)!,
+        message: error['message'] as String?,
+        details: error['details'],
+      );
+    } else if (replyMap['result'] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyMap['result'] as IsPlayingMessage?)!;
     }
   }
 }

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -50,7 +50,7 @@ class DurationMessage {
 }
 
 class StartMessage {
-  StartMessage(this.textureId, this.duration);
+  StartMessage(this.textureId, this.start);
   int textureId;
   int start;
 }
@@ -67,6 +67,12 @@ class CreateMessage {
 class MixWithOthersMessage {
   MixWithOthersMessage(this.mixWithOthers);
   bool mixWithOthers;
+}
+
+class IsPlayingMessage {
+  IsPlayingMessage(this.textureId, this.isPlaying);
+  int textureId;
+  bool isPlaying;
 }
 
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')
@@ -98,4 +104,6 @@ abstract class AVFoundationVideoPlayerApi {
   void pause(TextureMessage msg);
   @ObjCSelector('setMixWithOthers:')
   void setMixWithOthers(MixWithOthersMessage msg);
+  @ObjCSelector('isPlaying:')
+  IsPlayingMessage isPlaying(TextureMessage msg);
 }

--- a/packages/video_player/video_player_avfoundation/test/test_api.dart
+++ b/packages/video_player/video_player_avfoundation/test/test_api.dart
@@ -26,32 +26,36 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
     } else 
-    if (value is LoopingMessage) {
+    if (value is IsPlayingMessage) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
     } else 
-    if (value is MixWithOthersMessage) {
+    if (value is LoopingMessage) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PlaybackSpeedMessage) {
+    if (value is MixWithOthersMessage) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PositionMessage) {
+    if (value is PlaybackSpeedMessage) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
     } else 
-    if (value is StartMessage) {
+    if (value is PositionMessage) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else 
-    if (value is TextureMessage) {
+    if (value is StartMessage) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else 
-    if (value is VolumeMessage) {
+    if (value is TextureMessage) {
       buffer.putUint8(136);
+      writeValue(buffer, value.encode());
+    } else 
+    if (value is VolumeMessage) {
+      buffer.putUint8(137);
       writeValue(buffer, value.encode());
     } else 
 {
@@ -68,24 +72,27 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
         return DurationMessage.decode(readValue(buffer)!);
       
       case 130:       
-        return LoopingMessage.decode(readValue(buffer)!);
+        return IsPlayingMessage.decode(readValue(buffer)!);
       
       case 131:       
-        return MixWithOthersMessage.decode(readValue(buffer)!);
+        return LoopingMessage.decode(readValue(buffer)!);
       
       case 132:       
-        return PlaybackSpeedMessage.decode(readValue(buffer)!);
+        return MixWithOthersMessage.decode(readValue(buffer)!);
       
       case 133:       
-        return PositionMessage.decode(readValue(buffer)!);
+        return PlaybackSpeedMessage.decode(readValue(buffer)!);
       
       case 134:       
-        return StartMessage.decode(readValue(buffer)!);
+        return PositionMessage.decode(readValue(buffer)!);
       
       case 135:       
-        return TextureMessage.decode(readValue(buffer)!);
+        return StartMessage.decode(readValue(buffer)!);
       
       case 136:       
+        return TextureMessage.decode(readValue(buffer)!);
+      
+      case 137:       
         return VolumeMessage.decode(readValue(buffer)!);
       
       default:      
@@ -110,6 +117,7 @@ abstract class TestHostVideoPlayerApi {
   Future<void> seekTo(PositionMessage msg);
   void pause(TextureMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
+  IsPlayingMessage isPlaying(TextureMessage msg);
   static void setup(TestHostVideoPlayerApi? api, {BinaryMessenger? binaryMessenger}) {
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
@@ -313,6 +321,22 @@ abstract class TestHostVideoPlayerApi {
           assert(arg_msg != null, 'Argument for dev.flutter.pigeon.AVFoundationVideoPlayerApi.setMixWithOthers was null, expected non-null MixWithOthersMessage.');
           api.setMixWithOthers(arg_msg!);
           return <Object?, Object?>{};
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.AVFoundationVideoPlayerApi.isPlaying', codec, binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMockMessageHandler(null);
+      } else {
+        channel.setMockMessageHandler((Object? message) async {
+          assert(message != null, 'Argument for dev.flutter.pigeon.AVFoundationVideoPlayerApi.isPlaying was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final TextureMessage? arg_msg = (args[0] as TextureMessage?);
+          assert(arg_msg != null, 'Argument for dev.flutter.pigeon.AVFoundationVideoPlayerApi.isPlaying was null, expected non-null TextureMessage.');
+          final IsPlayingMessage output = api.isPlaying(arg_msg!);
+          return <Object?, Object?>{'result': output};
         });
       }
     }

--- a/packages/video_player/video_player_platform_interface/lib/messages.g.dart
+++ b/packages/video_player/video_player_platform_interface/lib/messages.g.dart
@@ -168,6 +168,25 @@ class BufferMessage {
   }
 }
 
+class IsPlayingMessage {
+  int? textureId;
+  bool? isPlaying;
+
+  Object encode() {
+    final Map<Object?, Object?> pigeonMap = <Object?, Object?>{};
+    pigeonMap['textureId'] = textureId;
+    pigeonMap['isPlaying'] = isPlaying;
+    return pigeonMap;
+  }
+
+  static IsPlayingMessage decode(Object message) {
+    final Map<Object?, Object?> pigeonMap = message as Map<Object?, Object?>;
+    return IsPlayingMessage()
+      ..textureId = pigeonMap['textureId'] as int?
+      ..isPlaying = pigeonMap['isPlaying'] as bool?;
+  }
+}
+
 class VideoPlayerApi {
   Future<void> initialize() async {
     const BasicMessageChannel<Object?> channel =
@@ -441,6 +460,29 @@ class VideoPlayerApi {
       );
     } else {
       // noop
+    }
+  }
+
+  Future<IsPlayingMessage> isPlaying(TextureMessage arg) async {
+    final Object encoded = arg.encode();
+    const BasicMessageChannel<Object?> channel =
+        BasicMessageChannel<Object?>('dev.flutter.pigeon.VideoPlayerApi.isPlaying', StandardMessageCodec());
+    final Map<Object?, Object?>? replyMap = await channel.send(encoded) as Map<Object?, Object?>?;
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+        details: null,
+      );
+    } else if (replyMap['error'] != null) {
+      final Map<Object?, Object?> error = replyMap['error'] as Map<Object?, Object?>;
+      throw PlatformException(
+        code: error['code'] as String,
+        message: error['message'] as String?,
+        details: error['details'],
+      );
+    } else {
+      return IsPlayingMessage.decode(replyMap['result']!);
     }
   }
 }

--- a/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
+++ b/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
@@ -105,7 +105,7 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   Future<bool> getIsPlaying(int textureId) async {
     final IsPlayingMessage response =
         await _api.isPlaying(TextureMessage()..textureId = textureId);
-    return response.isPlaying!;
+    return response.isPlaying ?? false;
   }
 
   @override

--- a/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
+++ b/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
@@ -102,6 +102,13 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
+  Future<bool> getIsPlaying(int textureId) async {
+    final IsPlayingMessage response =
+        await _api.isPlaying(TextureMessage()..textureId = textureId);
+    return response.isPlaying!;
+  }
+
+  @override
   Stream<VideoEvent> videoEventsFor(int textureId) {
     return _eventChannelFor(textureId)
         .receiveBroadcastStream()

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -114,7 +114,7 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
     throw UnimplementedError('setBuffer() has not been implemented.');
   }
 
-  /// Get latest isPlaying.
+  /// Get latest isPlaying status from ExoPlayer/AVPlayer
   Future<bool> getIsPlaying(int textureId) {
     throw UnimplementedError('isPlaying() has not been implemented.');
   }

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -113,6 +113,11 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
   Future<void> setBuffer(Buffer buffer) {
     throw UnimplementedError('setBuffer() has not been implemented.');
   }
+
+  /// Get latest isPlaying.
+  Future<bool> getIsPlaying(int textureId) {
+    throw UnimplementedError('isPlaying() has not been implemented.');
+  }
 }
 
 /// バッファを調整するための各パラメーター

--- a/packages/video_player/video_player_platform_interface/pigeons/messages.dart
+++ b/packages/video_player/video_player_platform_interface/pigeons/messages.dart
@@ -49,6 +49,11 @@ class BufferMessage {
   int bufferForPlaybackAfterRebufferMs;
 }
 
+class IsPlayingMessage {
+  int textureId;
+  bool isPlaying;
+}
+
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')
 abstract class VideoPlayerApi {
   void initialize();
@@ -63,6 +68,7 @@ abstract class VideoPlayerApi {
   void pause(TextureMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
   void setBuffer(BufferMessage msg);
+  IsPlayingMessage isPlaying(TextureMessage msg);
 }
 
 void configurePigeon(PigeonOptions opts) {

--- a/packages/video_player/video_player_platform_interface/test/test.dart
+++ b/packages/video_player/video_player_platform_interface/test/test.dart
@@ -22,6 +22,7 @@ abstract class TestHostVideoPlayerApi {
   void pause(TextureMessage arg);
   void setMixWithOthers(MixWithOthersMessage arg);
   void setBuffer(BufferMessage arg);
+  IsPlayingMessage isPlaying(TextureMessage arg);
   static void setup(TestHostVideoPlayerApi? api) {
     {
       const BasicMessageChannel<Object?> channel =
@@ -187,6 +188,20 @@ abstract class TestHostVideoPlayerApi {
           final BufferMessage input = BufferMessage.decode(message!);
           api.setBuffer(input);
           return <Object?, Object?>{};
+        });
+      }
+    }
+    {
+      const BasicMessageChannel<Object?> channel =
+          BasicMessageChannel<Object?>('dev.flutter.pigeon.VideoPlayerApi.isPlaying', StandardMessageCodec());
+      if (api == null) {
+        channel.setMockMessageHandler(null);
+      } else {
+        channel.setMockMessageHandler((Object? message) async {
+          assert(message != null, 'Argument for dev.flutter.pigeon.VideoPlayerApi.isPlaying was null. Expected TextureMessage.');
+          final TextureMessage input = TextureMessage.decode(message!);
+          final IsPlayingMessage output = api.isPlaying(input);
+          return <Object?, Object?>{'result': output.encode()};
         });
       }
     }


### PR DESCRIPTION
> バックグラウンド再生で、バックグラウンドからフォアグラウンドに戻る時に動画が止まることがある
（止まることは問題ではなく、video_controllのUIがLIVE映像の再生状態と相違してしまうのを修正してフリーズしたと勘違いさせないようにしたい）
別Appのメディアでの再生が原因っぽい
> - バックグラウンド再生をon
> - WTでLIVE映像再生して、バックグラウンド再生を開始
> - 別のApp（youtube）でなにかメディアを再生してWTのバックグラウンド再生止める
> - WTを開く-> 動画は停止しているのに、停止のボタンが表示されている（動画は停止しているので再生のボタンが表示されるべき）
> 毛：正しい動作ぽいね。バッググランドから復帰の際、Controlsを必ず表示させるようにしたら？

https://docs.google.com/spreadsheets/d/1dCpTTJWgeVewyHUT79Iw1ePrQYDBhXnJ9SWrj-P2QgU/edit#gid=1914530850

videoplayer側はisPlayingを独自のlocal変数で保持している。その更新はplay()とpauseが走ったときに行われるので今回のケースは考慮できていない。よってアプリが再度開かれたときにplayer側からisPlayingの値を受け取り更新し直す。

**2023/02/16**

昨日仙石さんと話して以下の実装方針に

plugin側: ExoPlayer, AVPlayerから取得するisPlayingを生やすだけ
app側: useRaceBackgroundAudioの内部でbackground再生有効時にpluginに新規で生やしたisPlayingを見てplay/pauseを実行する
