### PR TITLE
feat: Android の手動 PiP を動画専用の PipActivity 方式に変更

### DIFF
--- a/packages/video_player/video_player/example/android/app/build.gradle
+++ b/packages/video_player/video_player/example/android/app/build.gradle
@@ -37,7 +37,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.videoplayerexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/video_player/video_player/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/video_player/video_player/example/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
       android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|screenLayout|locale|layoutDirection"
       android:hardwareAccelerated="true"
       android:name="io.flutter.embedding.android.FlutterFragmentActivity"
-      android:supportsPictureInPicture="true"
       android:theme="@style/LaunchTheme"
       android:windowSoftInputMode="adjustResize">
       <intent-filter>

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -720,8 +720,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// Starts Picture-in-Picture mode.
   ///
   /// Supported on iOS (14.2+) and Android (8.0+).
-  /// On Android, the Activity must declare `android:supportsPictureInPicture="true"`
-  /// in the AndroidManifest.xml.
+  /// On Android, PiP は プラグイン内蔵の `PipActivity` で動作する。ホスト Activity への
+  /// `android:supportsPictureInPicture="true"` 追加は不要 (auto PiP も同 Activity 経由)。
   Future<void> startPictureInPicture() async {
     if (_isDisposedOrNotInitialized) {
       return;
@@ -771,8 +771,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// Enables or disables automatic Picture-in-Picture.
   ///
   /// When enabled:
-  /// - Android 12+ (API 31+): Uses native setAutoEnterEnabled
-  /// - Android 8-11 (API 26-30): Flutter-side fallback via AppLifecycleState
+  /// - Android (8.0+): ホスト Activity の `onUserLeaveHint` を検知して PipActivity を起動する。
+  ///   ホスト Activity は `FlutterFragmentActivity` (もしくは `ComponentActivity`
+  ///   のサブクラス) である必要がある。プレーンな `FlutterActivity` では動作しない。
   /// - iOS 14.2+: Uses canStartPictureInPictureAutomaticallyFromInline
   ///
   /// On unsupported versions, this is a no-op.
@@ -897,17 +898,11 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.paused:
-        // Don't pause during PiP — the video should keep playing in the PiP window.
+        // PiP 中は一時停止しない (PiP ウィンドウでそのまま再生を継続する)。
+        // Android の auto PiP はネイティブ側で onUserLeaveHint 経由で発火するため、
+        // ここで startPictureInPicture を呼ぶ必要はない (Activity は既に background 化しており
+        // Background Activity Start 制限に阻まれる可能性が高い)。
         if (_controller.value.isPipActive) {
-          return;
-        }
-        // API 26-30 fallback: auto PiP enabled and playing → start PiP manually.
-        // On API 31+, native setAutoEnterEnabled triggers PiP before this callback,
-        // so isPipActive is already true and we hit the early return above.
-        if (_controller.value.isAutoPipEnabled &&
-            _controller.value.isPlaying &&
-            defaultTargetPlatform == TargetPlatform.android) {
-          _controller.startPictureInPicture();
           return;
         }
         _wasPlayingBeforePause = _controller.value.isPlaying;

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -726,7 +726,16 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     if (_isDisposedOrNotInitialized) {
       return;
     }
-    await _videoPlayerPlatform.startPictureInPicture(_textureId);
+    // Pass the video widget position so Android animates the PiP window out
+    // of the video instead of the full screen.
+    final Rect? sourceRect = pipSourceRectProvider?.call();
+    await _videoPlayerPlatform.startPictureInPicture(
+      _textureId,
+      sourceRectLeft: sourceRect?.left,
+      sourceRectTop: sourceRect?.top,
+      sourceRectWidth: sourceRect?.width,
+      sourceRectHeight: sourceRect?.height,
+    );
   }
 
   /// Stops Picture-in-Picture mode.

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -45,6 +45,9 @@ android {
         implementation 'com.google.android.exoplayer:exoplayer-dash:2.18.1'
         implementation 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.18.1'
         implementation 'androidx.core:core:1.9.0'
+        // OnUserLeaveHintProvider を ComponentActivity が実装するのは 1.9.0 以降。
+        // Flutter/fragment 経由の transitive 依存 (1.8.1) では auto PiP が発火しないため明示指定する。
+        implementation 'androidx.activity:activity:1.9.0'
         testImplementation 'junit:junit:4.13.2'
         testImplementation 'androidx.test:core:1.3.0'
         testImplementation 'org.mockito:mockito-inline:4.7.0'

--- a/packages/video_player/video_player_android/android/src/main/AndroidManifest.xml
+++ b/packages/video_player/video_player_android/android/src/main/AndroidManifest.xml
@@ -1,3 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="io.flutter.plugins.videoplayer">
+  <application>
+    <!-- Dedicated activity that hosts only the video surface while in Picture-in-Picture.
+         Declared here so consuming apps need no manifest changes; it is stacked on the same
+         task as the host activity. -->
+    <activity
+      android:name="io.flutter.plugins.videoplayer.PipActivity"
+      android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
+      android:excludeFromRecents="true"
+      android:exported="false"
+      android:launchMode="singleTop"
+      android:supportsPictureInPicture="true"
+      android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen" />
+  </application>
 </manifest>

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -686,6 +686,7 @@ public class Messages {
       return pigeonResult;
     }
   }
+
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class PipStatusMessage {
     private @NonNull Long textureId;
@@ -741,6 +742,104 @@ public class Messages {
       return pigeonResult;
     }
   }
+
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class StartPipMessage {
+    private @NonNull Long textureId;
+    public @NonNull Long getTextureId() { return textureId; }
+    public void setTextureId(@NonNull Long setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"textureId\" is null.");
+      }
+      this.textureId = setterArg;
+    }
+
+    private @Nullable Double sourceRectLeft;
+    public @Nullable Double getSourceRectLeft() { return sourceRectLeft; }
+    public void setSourceRectLeft(@Nullable Double setterArg) {
+      this.sourceRectLeft = setterArg;
+    }
+
+    private @Nullable Double sourceRectTop;
+    public @Nullable Double getSourceRectTop() { return sourceRectTop; }
+    public void setSourceRectTop(@Nullable Double setterArg) {
+      this.sourceRectTop = setterArg;
+    }
+
+    private @Nullable Double sourceRectWidth;
+    public @Nullable Double getSourceRectWidth() { return sourceRectWidth; }
+    public void setSourceRectWidth(@Nullable Double setterArg) {
+      this.sourceRectWidth = setterArg;
+    }
+
+    private @Nullable Double sourceRectHeight;
+    public @Nullable Double getSourceRectHeight() { return sourceRectHeight; }
+    public void setSourceRectHeight(@Nullable Double setterArg) {
+      this.sourceRectHeight = setterArg;
+    }
+
+    /** Constructor is private to enforce null safety; use Builder. */
+    private StartPipMessage() {}
+    public static final class Builder {
+      private @Nullable Long textureId;
+      public @NonNull Builder setTextureId(@NonNull Long setterArg) {
+        this.textureId = setterArg;
+        return this;
+      }
+      private @Nullable Double sourceRectLeft;
+      public @NonNull Builder setSourceRectLeft(@Nullable Double setterArg) {
+        this.sourceRectLeft = setterArg;
+        return this;
+      }
+      private @Nullable Double sourceRectTop;
+      public @NonNull Builder setSourceRectTop(@Nullable Double setterArg) {
+        this.sourceRectTop = setterArg;
+        return this;
+      }
+      private @Nullable Double sourceRectWidth;
+      public @NonNull Builder setSourceRectWidth(@Nullable Double setterArg) {
+        this.sourceRectWidth = setterArg;
+        return this;
+      }
+      private @Nullable Double sourceRectHeight;
+      public @NonNull Builder setSourceRectHeight(@Nullable Double setterArg) {
+        this.sourceRectHeight = setterArg;
+        return this;
+      }
+      public @NonNull StartPipMessage build() {
+        StartPipMessage pigeonReturn = new StartPipMessage();
+        pigeonReturn.setTextureId(textureId);
+        pigeonReturn.setSourceRectLeft(sourceRectLeft);
+        pigeonReturn.setSourceRectTop(sourceRectTop);
+        pigeonReturn.setSourceRectWidth(sourceRectWidth);
+        pigeonReturn.setSourceRectHeight(sourceRectHeight);
+        return pigeonReturn;
+      }
+    }
+    @NonNull Map<String, Object> toMap() {
+      Map<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("textureId", textureId);
+      toMapResult.put("sourceRectLeft", sourceRectLeft);
+      toMapResult.put("sourceRectTop", sourceRectTop);
+      toMapResult.put("sourceRectWidth", sourceRectWidth);
+      toMapResult.put("sourceRectHeight", sourceRectHeight);
+      return toMapResult;
+    }
+    static @NonNull StartPipMessage fromMap(@NonNull Map<String, Object> map) {
+      StartPipMessage pigeonResult = new StartPipMessage();
+      Object textureId = map.get("textureId");
+      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer)textureId : (Long)textureId));
+      Object sourceRectLeft = map.get("sourceRectLeft");
+      pigeonResult.setSourceRectLeft((Double)sourceRectLeft);
+      Object sourceRectTop = map.get("sourceRectTop");
+      pigeonResult.setSourceRectTop((Double)sourceRectTop);
+      Object sourceRectWidth = map.get("sourceRectWidth");
+      pigeonResult.setSourceRectWidth((Double)sourceRectWidth);
+      Object sourceRectHeight = map.get("sourceRectHeight");
+      pigeonResult.setSourceRectHeight((Double)sourceRectHeight);
+      return pigeonResult;
+    }
+  }
   private static class AndroidVideoPlayerApiCodec extends StandardMessageCodec {
     public static final AndroidVideoPlayerApiCodec INSTANCE = new AndroidVideoPlayerApiCodec();
     private AndroidVideoPlayerApiCodec() {}
@@ -752,40 +851,43 @@ public class Messages {
         
         case (byte)129:         
           return CreateMessage.fromMap((Map<String, Object>) readValue(buffer));
-
+        
         case (byte)130:         
           return DurationMessage.fromMap((Map<String, Object>) readValue(buffer));
-
+        
         case (byte)131:         
           return IsPlayingMessage.fromMap((Map<String, Object>) readValue(buffer));
-
+        
         case (byte)132:         
           return LoopingMessage.fromMap((Map<String, Object>) readValue(buffer));
-
+        
         case (byte)133:         
-          return MixWithOthersMessage.fromMap((Map<String, Object>) readValue(buffer));
+          return MaxVideoResolutionMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)134:         
-          return PlaybackSpeedMessage.fromMap((Map<String, Object>) readValue(buffer));
+          return MixWithOthersMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)135:         
-          return PositionMessage.fromMap((Map<String, Object>) readValue(buffer));
+          return PipStatusMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)136:         
-          return TextureMessage.fromMap((Map<String, Object>) readValue(buffer));
+          return PlaybackSpeedMessage.fromMap((Map<String, Object>) readValue(buffer));
         
         case (byte)137:         
+          return PositionMessage.fromMap((Map<String, Object>) readValue(buffer));
+        
+        case (byte)138:         
+          return StartPipMessage.fromMap((Map<String, Object>) readValue(buffer));
+        
+        case (byte)139:         
+          return TextureMessage.fromMap((Map<String, Object>) readValue(buffer));
+        
+        case (byte)140:         
           return VolumeMessage.fromMap((Map<String, Object>) readValue(buffer));
-
-        case (byte)138:
-          return MaxVideoResolutionMessage.fromMap((Map<String, Object>) readValue(buffer));
-
-        case (byte)139:
-          return PipStatusMessage.fromMap((Map<String, Object>) readValue(buffer));
-
-        default:
+        
+        default:        
           return super.readValueOfType(type, buffer);
-
+        
       }
     }
     @Override
@@ -810,34 +912,38 @@ public class Messages {
         stream.write(132);
         writeValue(stream, ((LoopingMessage) value).toMap());
       } else 
-      if (value instanceof MixWithOthersMessage) {
+      if (value instanceof MaxVideoResolutionMessage) {
         stream.write(133);
+        writeValue(stream, ((MaxVideoResolutionMessage) value).toMap());
+      } else 
+      if (value instanceof MixWithOthersMessage) {
+        stream.write(134);
         writeValue(stream, ((MixWithOthersMessage) value).toMap());
       } else 
+      if (value instanceof PipStatusMessage) {
+        stream.write(135);
+        writeValue(stream, ((PipStatusMessage) value).toMap());
+      } else 
       if (value instanceof PlaybackSpeedMessage) {
-        stream.write(134);
+        stream.write(136);
         writeValue(stream, ((PlaybackSpeedMessage) value).toMap());
       } else 
       if (value instanceof PositionMessage) {
-        stream.write(135);
+        stream.write(137);
         writeValue(stream, ((PositionMessage) value).toMap());
       } else 
+      if (value instanceof StartPipMessage) {
+        stream.write(138);
+        writeValue(stream, ((StartPipMessage) value).toMap());
+      } else 
       if (value instanceof TextureMessage) {
-        stream.write(136);
+        stream.write(139);
         writeValue(stream, ((TextureMessage) value).toMap());
       } else 
       if (value instanceof VolumeMessage) {
-        stream.write(137);
+        stream.write(140);
         writeValue(stream, ((VolumeMessage) value).toMap());
       } else 
-      if (value instanceof MaxVideoResolutionMessage) {
-        stream.write(138);
-        writeValue(stream, ((MaxVideoResolutionMessage) value).toMap());
-      } else
-      if (value instanceof PipStatusMessage) {
-        stream.write(139);
-        writeValue(stream, ((PipStatusMessage) value).toMap());
-      } else
 {
         super.writeValue(stream, value);
       }
@@ -861,7 +967,7 @@ public class Messages {
     void setBuffer(@NonNull BufferMessage msg);
     void setMaxVideoResolution(@NonNull MaxVideoResolutionMessage msg);
     @NonNull IsPlayingMessage isPlaying(@NonNull TextureMessage msg);
-    void startPictureInPicture(@NonNull TextureMessage msg);
+    void startPictureInPicture(@NonNull StartPipMessage msg);
     void stopPictureInPicture(@NonNull TextureMessage msg);
     @NonNull PipStatusMessage isPictureInPictureSupported(@NonNull TextureMessage msg);
     @NonNull PipStatusMessage isPictureInPictureActive(@NonNull TextureMessage msg);
@@ -1237,7 +1343,7 @@ public class Messages {
             Map<String, Object> wrapped = new HashMap<>();
             try {
               ArrayList<Object> args = (ArrayList<Object>)message;
-              TextureMessage msgArg = (TextureMessage)args.get(0);
+              StartPipMessage msgArg = (StartPipMessage)args.get(0);
               if (msgArg == null) {
                 throw new NullPointerException("msgArg unexpectedly null.");
               }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivity.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivity.java
@@ -1,0 +1,206 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.videoplayer;
+
+import android.app.Activity;
+import android.app.PictureInPictureParams;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.graphics.Color;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Rational;
+import android.view.Gravity;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import io.flutter.Log;
+
+/**
+ * A minimal activity that hosts only the video surface while in Picture-in-Picture mode. Running
+ * PiP in a dedicated activity (instead of the Flutter host activity) keeps the main app usable
+ * behind the PiP window and guarantees the PiP window shows nothing but the video.
+ *
+ * <p>On API 33+ this activity is launched directly into PiP via {@code
+ * ActivityOptions.makeLaunchIntoPip}. On API 26-32 it briefly appears full screen (black) and
+ * enters PiP right after creation.
+ *
+ * <p>The activity is stacked on the same task as the host activity, so finishing it after the PiP
+ * window is expanded reveals the host activity underneath.
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+public final class PipActivity extends Activity {
+  static final String EXTRA_LAUNCHED_INTO_PIP = "launched_into_pip";
+  private static final String TAG = "VideoPlayerPip";
+
+  private boolean activityStarted = false;
+  private boolean enterPipRequested = false;
+
+  private final SurfaceHolder.Callback surfaceCallback =
+      new SurfaceHolder.Callback() {
+        @Override
+        public void surfaceCreated(@NonNull SurfaceHolder holder) {
+          VideoPlayer player = PipActivityController.getPlayer();
+          if (player != null) {
+            Log.d(TAG, "PiP surface created; switching video output to PipActivity");
+            player.attachPipSurface(holder.getSurface());
+          }
+        }
+
+        @Override
+        public void surfaceChanged(@NonNull SurfaceHolder holder, int format, int w, int h) {}
+
+        @Override
+        public void surfaceDestroyed(@NonNull SurfaceHolder holder) {
+          Log.d(TAG, "PiP surface destroyed");
+          PipActivityController.onPipSurfaceDestroyed();
+        }
+      };
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    VideoPlayer player = PipActivityController.getPlayer();
+    if (player == null) {
+      Log.w(TAG, "No active player for PipActivity; finishing");
+      finish();
+      return;
+    }
+    PipActivityController.onActivityCreated(this);
+    setContentView(createContentView(player));
+
+    if (getIntent().getBooleanExtra(EXTRA_LAUNCHED_INTO_PIP, false)) {
+      Log.d(TAG, "Launched directly into PiP (makeLaunchIntoPip)");
+      enterPipRequested = true;
+    } else {
+      enterPipIfNeeded("onCreate");
+    }
+  }
+
+  private View createContentView(@NonNull VideoPlayer player) {
+    FrameLayout root = new FrameLayout(this);
+    root.setBackgroundColor(Color.BLACK);
+
+    Rational aspectRatio = player.getVideoAspectRatio();
+    AspectRatioFrameLayout videoContainer =
+        new AspectRatioFrameLayout(this, aspectRatio.floatValue());
+
+    SurfaceView surfaceView = new SurfaceView(this);
+    surfaceView.getHolder().addCallback(surfaceCallback);
+    videoContainer.addView(
+        surfaceView,
+        new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+
+    root.addView(
+        videoContainer,
+        new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            Gravity.CENTER));
+    return root;
+  }
+
+  // API 26-32 entry point. Entering from onCreate usually works; onWindowFocusChanged is the
+  // fallback for devices that reject the request before the window is attached.
+  private void enterPipIfNeeded(@NonNull String caller) {
+    if (enterPipRequested || isInPictureInPictureMode()) {
+      return;
+    }
+    VideoPlayer player = PipActivityController.getPlayer();
+    if (player == null) {
+      return;
+    }
+    PictureInPictureParams params =
+        new PictureInPictureParams.Builder().setAspectRatio(player.getVideoAspectRatio()).build();
+    boolean entered = enterPictureInPictureMode(params);
+    Log.d(TAG, "enterPictureInPictureMode from " + caller + " -> " + entered);
+    if (entered) {
+      enterPipRequested = true;
+    }
+  }
+
+  @Override
+  public void onWindowFocusChanged(boolean hasFocus) {
+    super.onWindowFocusChanged(hasFocus);
+    if (hasFocus) {
+      enterPipIfNeeded("onWindowFocusChanged");
+    }
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    activityStarted = true;
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    activityStarted = false;
+  }
+
+  @Override
+  public void onPictureInPictureModeChanged(
+      boolean isInPictureInPictureMode, @NonNull Configuration newConfig) {
+    super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
+    Log.d(
+        TAG,
+        "onPictureInPictureModeChanged: "
+            + isInPictureInPictureMode
+            + " started="
+            + activityStarted);
+    if (isInPictureInPictureMode) {
+      PipActivityController.onPipEntered();
+      return;
+    }
+    // When the PiP window is dismissed the activity is stopped before this callback fires,
+    // whereas expanding back to full screen keeps it started.
+    if (activityStarted) {
+      PipActivityController.endPip(false, "expanded to full screen");
+    } else {
+      PipActivityController.endPip(true, "dismissed");
+    }
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    PipActivityController.onActivityDestroyed(this);
+  }
+
+  /** Sizes its content to the video aspect ratio so the full-screen phase is letterboxed. */
+  private static final class AspectRatioFrameLayout extends FrameLayout {
+    private final float aspectRatio;
+
+    AspectRatioFrameLayout(@NonNull Context context, float aspectRatio) {
+      super(context);
+      this.aspectRatio = aspectRatio > 0 ? aspectRatio : 16f / 9f;
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+      int width = MeasureSpec.getSize(widthMeasureSpec);
+      int height = MeasureSpec.getSize(heightMeasureSpec);
+      if (width == 0 || height == 0) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        return;
+      }
+      if ((float) width / height > aspectRatio) {
+        width = (int) (height * aspectRatio);
+      } else {
+        height = (int) (width / aspectRatio);
+      }
+      super.onMeasure(
+          MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+          MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY));
+    }
+  }
+}

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivity.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivity.java
@@ -5,12 +5,14 @@
 package io.flutter.plugins.videoplayer;
 
 import android.app.Activity;
-import android.app.PictureInPictureParams;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Rational;
 import android.view.Gravity;
 import android.view.SurfaceHolder;
@@ -40,8 +42,14 @@ public final class PipActivity extends Activity {
   static final String EXTRA_LAUNCHED_INTO_PIP = "launched_into_pip";
   private static final String TAG = "VideoPlayerPip";
 
+  // Keeps this activity alive after the expand transition starts, so the system animation
+  // (which lands the video on the source rect) finishes before the host activity is revealed.
+  private static final long EXPAND_TRANSITION_GRACE_MS = 400;
+
+  private final Handler mainHandler = new Handler(Looper.getMainLooper());
   private boolean activityStarted = false;
   private boolean enterPipRequested = false;
+  @Nullable private AspectRatioFrameLayout videoContainer;
 
   private final SurfaceHolder.Callback surfaceCallback =
       new SurfaceHolder.Callback() {
@@ -74,23 +82,27 @@ public final class PipActivity extends Activity {
       return;
     }
     PipActivityController.onActivityCreated(this);
-    setContentView(createContentView(player));
+    boolean launchedIntoPip = getIntent().getBooleanExtra(EXTRA_LAUNCHED_INTO_PIP, false);
+    setContentView(createContentView(player, launchedIntoPip));
 
-    if (getIntent().getBooleanExtra(EXTRA_LAUNCHED_INTO_PIP, false)) {
+    if (launchedIntoPip) {
       Log.d(TAG, "Launched directly into PiP (makeLaunchIntoPip)");
       enterPipRequested = true;
+      // When the activity is created directly in PiP mode there is no mode
+      // *change*, so onPictureInPictureModeChanged(true) may never fire.
+      // Report PiP entry here instead (onPipEntered is idempotent).
+      PipActivityController.onPipEntered();
     } else {
       enterPipIfNeeded("onCreate");
     }
   }
 
-  private View createContentView(@NonNull VideoPlayer player) {
+  private View createContentView(@NonNull VideoPlayer player, boolean launchedIntoPip) {
     FrameLayout root = new FrameLayout(this);
     root.setBackgroundColor(Color.BLACK);
 
     Rational aspectRatio = player.getVideoAspectRatio();
-    AspectRatioFrameLayout videoContainer =
-        new AspectRatioFrameLayout(this, aspectRatio.floatValue());
+    videoContainer = new AspectRatioFrameLayout(this, aspectRatio.floatValue());
 
     SurfaceView surfaceView = new SurfaceView(this);
     surfaceView.getHolder().addCallback(surfaceCallback);
@@ -99,13 +111,34 @@ public final class PipActivity extends Activity {
         new FrameLayout.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
-    root.addView(
-        videoContainer,
-        new FrameLayout.LayoutParams(
-            ViewGroup.LayoutParams.WRAP_CONTENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT,
-            Gravity.CENTER));
+    root.addView(videoContainer, videoLayoutParams(launchedIntoPip));
     return root;
+  }
+
+  /**
+   * Layout for the video container. While in PiP the video fills the window (whose aspect ratio
+   * already matches the video). In full-screen phases it sits exactly on the source rect — the
+   * on-screen position of the Flutter video widget — so both the enter animation (API 26-32) and
+   * the expand-to-full-screen animation land the video on the widget, making the hand-off to the
+   * host activity seamless. Without a source rect it falls back to letterboxed center.
+   */
+  private FrameLayout.LayoutParams videoLayoutParams(boolean fillWindow) {
+    Rect sourceRect = PipActivityController.getSourceRectHint();
+    if (!fillWindow && sourceRect != null) {
+      FrameLayout.LayoutParams params =
+          new FrameLayout.LayoutParams(sourceRect.width(), sourceRect.height());
+      params.leftMargin = sourceRect.left;
+      params.topMargin = sourceRect.top;
+      return params;
+    }
+    return new FrameLayout.LayoutParams(
+        ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.CENTER);
+  }
+
+  private void applyVideoLayout(boolean fillWindow) {
+    if (videoContainer != null) {
+      videoContainer.setLayoutParams(videoLayoutParams(fillWindow));
+    }
   }
 
   // API 26-32 entry point. Entering from onCreate usually works; onWindowFocusChanged is the
@@ -118,9 +151,7 @@ public final class PipActivity extends Activity {
     if (player == null) {
       return;
     }
-    PictureInPictureParams params =
-        new PictureInPictureParams.Builder().setAspectRatio(player.getVideoAspectRatio()).build();
-    boolean entered = enterPictureInPictureMode(params);
+    boolean entered = enterPictureInPictureMode(PipActivityController.buildPipParams(player));
     Log.d(TAG, "enterPictureInPictureMode from " + caller + " -> " + entered);
     if (entered) {
       enterPipRequested = true;
@@ -158,21 +189,37 @@ public final class PipActivity extends Activity {
             + " started="
             + activityStarted);
     if (isInPictureInPictureMode) {
+      applyVideoLayout(true);
       PipActivityController.onPipEntered();
       return;
     }
     // When the PiP window is dismissed the activity is stopped before this callback fires,
     // whereas expanding back to full screen keeps it started.
     if (activityStarted) {
-      PipActivityController.endPip(false, "expanded to full screen");
+      // Show the video on the source rect so the system's expand animation lands it exactly on
+      // the Flutter video widget, then hand off to the host activity underneath.
+      applyVideoLayout(false);
+      Log.d(TAG, "Expanded to full screen; finishing after transition grace period");
+      mainHandler.postDelayed(
+          () -> PipActivityController.endPip(false, "expanded to full screen"),
+          EXPAND_TRANSITION_GRACE_MS);
     } else {
-      PipActivityController.endPip(true, "dismissed");
+      PipActivityController.endPipFromWindowClose();
     }
+  }
+
+  @Override
+  public void finish() {
+    super.finish();
+    // Suppress the close animation: the host activity underneath already shows the video at the
+    // same position, so any transition would break the seamless hand-off.
+    overridePendingTransition(0, 0);
   }
 
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    mainHandler.removeCallbacksAndMessages(null);
     PipActivityController.onActivityDestroyed(this);
   }
 

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivityController.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivityController.java
@@ -1,0 +1,155 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.videoplayer;
+
+import android.app.Activity;
+import android.app.ActivityOptions;
+import android.app.PictureInPictureParams;
+import android.content.Intent;
+import android.os.Build;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.flutter.Log;
+import java.lang.ref.WeakReference;
+
+/**
+ * Coordinates the dedicated {@link PipActivity} with the {@link VideoPlayer} whose video it shows.
+ *
+ * <p>Members are static because {@link PipActivity} is instantiated by the Android framework and
+ * needs a process-wide handle to reach the active player. Only one dedicated PiP session can exist
+ * at a time. All methods must be called on the main thread.
+ */
+final class PipActivityController {
+  /** Notified when the dedicated PiP session ends, regardless of how it ended. */
+  interface OnPipEndedListener {
+    void onPipEnded(@Nullable VideoPlayer player);
+  }
+
+  private static final String TAG = "VideoPlayerPip";
+
+  @Nullable private static VideoPlayer player;
+  @Nullable private static WeakReference<PipActivity> activityRef;
+  private static boolean inPipMode = false;
+  @Nullable private static OnPipEndedListener onPipEndedListener;
+
+  private PipActivityController() {}
+
+  static void setOnPipEndedListener(@Nullable OnPipEndedListener listener) {
+    onPipEndedListener = listener;
+  }
+
+  /** Launches the dedicated PiP activity showing the given player's video. */
+  static void launch(@NonNull Activity hostActivity, @NonNull VideoPlayer targetPlayer) {
+    if (player != null && player != targetPlayer) {
+      endPip(false, "replaced by another player");
+    }
+    player = targetPlayer;
+    Intent intent = new Intent(hostActivity, PipActivity.class);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      PictureInPictureParams params =
+          new PictureInPictureParams.Builder()
+              .setAspectRatio(targetPlayer.getVideoAspectRatio())
+              .build();
+      intent.putExtra(PipActivity.EXTRA_LAUNCHED_INTO_PIP, true);
+      Log.d(TAG, "Launching PipActivity via makeLaunchIntoPip (API 33+)");
+      hostActivity.startActivity(intent, ActivityOptions.makeLaunchIntoPip(params).toBundle());
+    } else {
+      Log.d(TAG, "Launching PipActivity; entering PiP after creation (API < 33)");
+      hostActivity.startActivity(intent);
+    }
+  }
+
+  @Nullable
+  static VideoPlayer getPlayer() {
+    return player;
+  }
+
+  static boolean isInPipMode() {
+    return inPipMode;
+  }
+
+  static void onActivityCreated(@NonNull PipActivity activity) {
+    activityRef = new WeakReference<>(activity);
+  }
+
+  static void onPipEntered() {
+    if (player == null) {
+      return;
+    }
+    inPipMode = true;
+    player.notifyPipStarted();
+  }
+
+  /**
+   * Called when the PiP surface is torn down. Restores the Flutter texture as the video output if
+   * the session has not been ended through {@link #endPip} yet.
+   */
+  static void onPipSurfaceDestroyed() {
+    if (player != null) {
+      player.restoreFlutterSurface();
+    }
+  }
+
+  /**
+   * Ends the dedicated PiP session: restores video output to the Flutter texture, optionally
+   * pauses playback, notifies Dart, and finishes the PiP activity. Safe to call multiple times.
+   */
+  static void endPip(boolean pauseVideo, @NonNull String reason) {
+    VideoPlayer endedPlayer = player;
+    if (endedPlayer == null && activityRef == null) {
+      return;
+    }
+    Log.d(TAG, "Ending dedicated PiP: " + reason);
+    boolean wasInPipMode = inPipMode;
+    inPipMode = false;
+    player = null;
+    if (endedPlayer != null) {
+      endedPlayer.restoreFlutterSurface();
+      if (pauseVideo) {
+        endedPlayer.pause();
+      }
+      if (wasInPipMode) {
+        endedPlayer.notifyPipStopped();
+      }
+    }
+    finishActivityAndNotify(endedPlayer);
+  }
+
+  /**
+   * Called at the start of {@link VideoPlayer#dispose()}. Tears the session down without touching
+   * the player, which is about to release its ExoPlayer.
+   */
+  static void onPlayerDisposed(@NonNull VideoPlayer disposedPlayer) {
+    if (player != disposedPlayer) {
+      return;
+    }
+    Log.d(TAG, "Player disposed while its dedicated PiP session was active");
+    inPipMode = false;
+    player = null;
+    finishActivityAndNotify(disposedPlayer);
+  }
+
+  /** Called from {@link PipActivity#onDestroy()} as a safety net for unexpected teardown. */
+  static void onActivityDestroyed(@NonNull PipActivity activity) {
+    if (activityRef != null && activityRef.get() == activity) {
+      endPip(false, "activity destroyed");
+    }
+  }
+
+  private static void finishActivityAndNotify(@Nullable VideoPlayer endedPlayer) {
+    finishActivity();
+    if (onPipEndedListener != null) {
+      onPipEndedListener.onPipEnded(endedPlayer);
+    }
+  }
+
+  private static void finishActivity() {
+    PipActivity activity = activityRef != null ? activityRef.get() : null;
+    activityRef = null;
+    if (activity != null && !activity.isFinishing()) {
+      activity.finish();
+    }
+  }
+}

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivityController.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivityController.java
@@ -8,9 +8,13 @@ import android.app.Activity;
 import android.app.ActivityOptions;
 import android.app.PictureInPictureParams;
 import android.content.Intent;
+import android.graphics.Rect;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import io.flutter.Log;
 import java.lang.ref.WeakReference;
 
@@ -29,10 +33,17 @@ final class PipActivityController {
 
   private static final String TAG = "VideoPlayerPip";
 
+  // How long after the PiP window closes to wait before deciding whether the close was an
+  // "expand back to the app" (host regains focus -> keep playing) or a plain dismissal.
+  private static final long WINDOW_CLOSE_PAUSE_DECISION_MS = 500;
+
   @Nullable private static VideoPlayer player;
   @Nullable private static WeakReference<PipActivity> activityRef;
+  @Nullable private static WeakReference<Activity> hostActivityRef;
   private static boolean inPipMode = false;
   @Nullable private static OnPipEndedListener onPipEndedListener;
+  // Screen rect (physical pixels) of the video widget, used as the PiP enter-animation origin.
+  @Nullable private static Rect sourceRectHint;
 
   private PipActivityController() {}
 
@@ -40,30 +51,66 @@ final class PipActivityController {
     onPipEndedListener = listener;
   }
 
-  /** Launches the dedicated PiP activity showing the given player's video. */
-  static void launch(@NonNull Activity hostActivity, @NonNull VideoPlayer targetPlayer) {
+  /**
+   * Launches the dedicated PiP activity showing the given player's video. When non-null,
+   * {@code sourceRectHintPx} makes the system animate the PiP window out of that on-screen rect
+   * instead of the full screen.
+   */
+  @RequiresApi(Build.VERSION_CODES.O)
+  static void launch(
+      @NonNull Activity hostActivity,
+      @NonNull VideoPlayer targetPlayer,
+      @Nullable Rect sourceRectHintPx) {
     if (player != null && player != targetPlayer) {
       endPip(false, "replaced by another player");
     }
     player = targetPlayer;
+    hostActivityRef = new WeakReference<>(hostActivity);
+    sourceRectHint = sourceRectHintPx;
+    // Give the host activity the same source rect hint, so the system's "expand back to the
+    // app" transition also aims at the video widget position.
+    hostActivity.setPictureInPictureParams(buildPipParams(targetPlayer));
     Intent intent = new Intent(hostActivity, PipActivity.class);
+    // Launching the PiP activity must not look like the user leaving the host activity,
+    // otherwise the host's onUserLeaveHint would fire and could re-trigger auto PiP.
+    intent.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      PictureInPictureParams params =
-          new PictureInPictureParams.Builder()
-              .setAspectRatio(targetPlayer.getVideoAspectRatio())
-              .build();
       intent.putExtra(PipActivity.EXTRA_LAUNCHED_INTO_PIP, true);
-      Log.d(TAG, "Launching PipActivity via makeLaunchIntoPip (API 33+)");
-      hostActivity.startActivity(intent, ActivityOptions.makeLaunchIntoPip(params).toBundle());
+      Log.d(
+          TAG,
+          "Launching PipActivity via makeLaunchIntoPip (API 33+), sourceRectHint="
+              + sourceRectHintPx);
+      hostActivity.startActivity(
+          intent, ActivityOptions.makeLaunchIntoPip(buildPipParams(targetPlayer)).toBundle());
     } else {
       Log.d(TAG, "Launching PipActivity; entering PiP after creation (API < 33)");
       hostActivity.startActivity(intent);
     }
   }
 
+  /**
+   * Builds the PiP params for the given player: the video aspect ratio plus, when set, the source
+   * rect the enter animation should start from.
+   */
+  @RequiresApi(Build.VERSION_CODES.O)
+  static PictureInPictureParams buildPipParams(@NonNull VideoPlayer targetPlayer) {
+    PictureInPictureParams.Builder builder =
+        new PictureInPictureParams.Builder().setAspectRatio(targetPlayer.getVideoAspectRatio());
+    if (sourceRectHint != null) {
+      builder.setSourceRectHint(sourceRectHint);
+    }
+    return builder.build();
+  }
+
   @Nullable
   static VideoPlayer getPlayer() {
     return player;
+  }
+
+  /** Screen rect of the video widget, used to lay out and animate PiP transitions. */
+  @Nullable
+  static Rect getSourceRectHint() {
+    return sourceRectHint;
   }
 
   static boolean isInPipMode() {
@@ -75,7 +122,9 @@ final class PipActivityController {
   }
 
   static void onPipEntered() {
-    if (player == null) {
+    // Idempotent: with makeLaunchIntoPip this is called from onCreate, and
+    // onPictureInPictureModeChanged(true) may or may not fire afterwards.
+    if (player == null || inPipMode) {
       return;
     }
     inPipMode = true;
@@ -93,6 +142,32 @@ final class PipActivityController {
   }
 
   /**
+   * Ends the session after the system closed the PiP window. On API 33+ this happens both when
+   * the user dismisses the window (X) and when they expand it back to the app — the dedicated
+   * activity is stopped in both cases, so they are indistinguishable here. Decide whether to
+   * pause after a grace period: if the host activity regained focus the close was an
+   * expand-back-to-app, so playback continues; otherwise it was a plain dismissal, so pause.
+   */
+  static void endPipFromWindowClose() {
+    VideoPlayer endedPlayer = player;
+    Activity hostActivity = hostActivityRef != null ? hostActivityRef.get() : null;
+    endPip(false, "window closed");
+    if (endedPlayer == null) {
+      return;
+    }
+    new Handler(Looper.getMainLooper())
+        .postDelayed(
+            () -> {
+              boolean hostFocused = hostActivity != null && hostActivity.hasWindowFocus();
+              Log.d(TAG, "PiP window closed; hostFocused=" + hostFocused);
+              if (!hostFocused && !endedPlayer.isDisposed()) {
+                endedPlayer.pause();
+              }
+            },
+            WINDOW_CLOSE_PAUSE_DECISION_MS);
+  }
+
+  /**
    * Ends the dedicated PiP session: restores video output to the Flutter texture, optionally
    * pauses playback, notifies Dart, and finishes the PiP activity. Safe to call multiple times.
    */
@@ -105,6 +180,7 @@ final class PipActivityController {
     boolean wasInPipMode = inPipMode;
     inPipMode = false;
     player = null;
+    sourceRectHint = null;
     if (endedPlayer != null) {
       endedPlayer.restoreFlutterSurface();
       if (pauseVideo) {
@@ -128,6 +204,7 @@ final class PipActivityController {
     Log.d(TAG, "Player disposed while its dedicated PiP session was active");
     inPipMode = false;
     player = null;
+    sourceRectHint = null;
     finishActivityAndNotify(disposedPlayer);
   }
 

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivityController.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/PipActivityController.java
@@ -67,12 +67,9 @@ final class PipActivityController {
     player = targetPlayer;
     hostActivityRef = new WeakReference<>(hostActivity);
     sourceRectHint = sourceRectHintPx;
-    // Give the host activity the same source rect hint, so the system's "expand back to the
-    // app" transition also aims at the video widget position.
-    hostActivity.setPictureInPictureParams(buildPipParams(targetPlayer));
     Intent intent = new Intent(hostActivity, PipActivity.class);
-    // Launching the PiP activity must not look like the user leaving the host activity,
-    // otherwise the host's onUserLeaveHint would fire and could re-trigger auto PiP.
+    // PipActivity 起動時にホストの onUserLeaveHint を誤発火させないためのフラグ。
+    // ここで発火してしまうと、auto PiP リスナが「新規の離脱」と判定して二重起動しうる。
     intent.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       intent.putExtra(PipActivity.EXTRA_LAUNCHED_INTO_PIP, true);

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -8,7 +8,6 @@ import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
 import static com.google.android.exoplayer2.Player.REPEAT_MODE_OFF;
 
 import android.app.Activity;
-import android.app.PictureInPictureParams;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -462,40 +461,18 @@ final class VideoPlayer {
   void setAutoPictureInPicture(boolean enabled) {
     this.autoPipEnabled = enabled;
 
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-      // API 31 未満では setAutoEnterEnabled が使えない。
-      // Flutter 側のフォールバックに委ねるため、要求された enabled 値をそのまま通知。
-      sendAutoPipChangedEvent(enabled);
-      return;
-    }
-    if (activity == null) {
-      android.util.Log.w("AutoPiP", "activity is null, cannot set auto PiP");
-      sendAutoPipChangedEvent(false);
-      return;
-    }
-
-    if (pipRequestHandler != null && enabled) {
+    // ホスト Activity 側の PiP 化 (setAutoEnterEnabled) は使わない。
+    // 実際の PiP 発火は VideoPlayerPlugin が onUserLeaveHint を検知して行うため、
+    // ここではフラグを保持し Dart 側に状態を通知するだけで良い。
+    if (enabled && pipRequestHandler != null) {
       pipRequestHandler.onPipRequested();
     }
-
-    applyAutoPipParams(enabled);
 
     sendAutoPipChangedEvent(enabled);
   }
 
   boolean isAutoPipEnabled() {
     return autoPipEnabled;
-  }
-
-  /**
-   * Temporarily clears autoEnterEnabled on the host activity while the dedicated PiP activity is
-   * showing, so leaving the app cannot pull the host activity into a second PiP window. The
-   * autoPipEnabled flag is kept so {@link #updateAutoPipParams()} can restore the params later.
-   */
-  void suspendAutoEnter() {
-    if (autoPipEnabled) {
-      applyAutoPipParams(false);
-    }
   }
 
   /** Returns the video aspect ratio, defaulting to 16:9 if unavailable. */
@@ -545,31 +522,7 @@ final class VideoPlayer {
       }
 
       eventSink.success(event);
-
-      // Update PiP params with the actual video aspect ratio now that the
-      // video format is known. When setAutoPictureInPicture was called before
-      // initialization, getVideoAspectRatio() returned the 16:9 default.
-      updateAutoPipParams();
     }
-  }
-
-  /** Re-applies auto PiP params with the current video aspect ratio if enabled. */
-  void updateAutoPipParams() {
-    if (autoPipEnabled) {
-      applyAutoPipParams(true);
-    }
-  }
-
-  /** Sets host-activity PiP params with the given autoEnter flag. */
-  private void applyAutoPipParams(boolean autoEnterEnabled) {
-    if (activity == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-      return;
-    }
-    activity.setPictureInPictureParams(
-        new PictureInPictureParams.Builder()
-            .setAspectRatio(getVideoAspectRatio())
-            .setAutoEnterEnabled(autoEnterEnabled)
-            .build());
   }
 
   boolean isDisposed() {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -367,19 +367,57 @@ final class VideoPlayer {
       pipRequestHandler.onPipRequested();
     }
 
-    PictureInPictureParams params =
-        new PictureInPictureParams.Builder().setAspectRatio(getVideoAspectRatio()).build();
-    activity.enterPictureInPictureMode(params);
+    // Manual PiP runs in a dedicated activity so the main app stays usable behind the PiP
+    // window and the window shows nothing but the video.
+    PipActivityController.launch(activity, this);
+  }
+
+  /** Redirects video output to the dedicated PiP activity's surface. */
+  void attachPipSurface(@NonNull Surface pipSurface) {
+    exoPlayer.setVideoSurface(pipSurface);
+  }
+
+  /** Restores video output to the Flutter texture. Safe to call repeatedly. */
+  void restoreFlutterSurface() {
+    if (surface != null) {
+      exoPlayer.setVideoSurface(surface);
+    }
+  }
+
+  void notifyPipStarted() {
+    if (videoPlayerCallbacks != null) {
+      videoPlayerCallbacks.onPictureInPictureStarted();
+    }
+  }
+
+  void notifyPipStopped() {
+    if (videoPlayerCallbacks != null) {
+      videoPlayerCallbacks.onPictureInPictureStopped();
+    }
   }
 
   void stopPictureInPicture() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
       return;
     }
+    if (PipActivityController.getPlayer() == this && PipActivityController.isInPipMode()) {
+      // Bring the main task forward first so ending PiP doesn't drop the user on the launcher.
+      if (activity != null) {
+        bringHostActivityToFront();
+      }
+      PipActivityController.endPip(false, "stopPictureInPicture");
+      return;
+    }
     if (activity == null || !activity.isInPictureInPictureMode()) {
       return;
     }
-    // Android has no direct "exit PiP" API. Bring the activity to front to restore full screen.
+    // Auto PiP keeps the host activity itself in PiP, and Android has no direct "exit PiP" API.
+    // Bring the activity to front to restore full screen.
+    bringHostActivityToFront();
+  }
+
+  /** Brings the host activity to the front, restoring it to full screen. */
+  private void bringHostActivityToFront() {
     Intent intent = new Intent(activity, activity.getClass());
     intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
     activity.startActivity(intent);
@@ -395,6 +433,9 @@ final class VideoPlayer {
   }
 
   boolean isPictureInPictureActive() {
+    if (PipActivityController.getPlayer() == this && PipActivityController.isInPipMode()) {
+      return true;
+    }
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N || activity == null) {
       return false;
     }
@@ -434,8 +475,17 @@ final class VideoPlayer {
     return autoPipEnabled;
   }
 
+  /**
+   * Temporarily clears autoEnterEnabled on the host activity while the dedicated PiP activity is
+   * showing, so leaving the app cannot pull the host activity into a second PiP window. The
+   * autoPipEnabled flag is kept so {@link #updateAutoPipParams()} can restore the params later.
+   */
+  void suspendAutoEnter() {
+    applyAutoPipParams(false);
+  }
+
   /** Returns the video aspect ratio, defaulting to 16:9 if unavailable. */
-  private Rational getVideoAspectRatio() {
+  Rational getVideoAspectRatio() {
     Format videoFormat = exoPlayer.getVideoFormat();
     if (videoFormat != null && videoFormat.width > 0 && videoFormat.height > 0) {
       return new Rational(videoFormat.width, videoFormat.height);
@@ -490,21 +540,25 @@ final class VideoPlayer {
   }
 
   /** Re-applies auto PiP params with the current video aspect ratio if enabled. */
-  private void updateAutoPipParams() {
-    if (!autoPipEnabled || activity == null) {
+  void updateAutoPipParams() {
+    applyAutoPipParams(true);
+  }
+
+  /** Sets host-activity PiP params with the given autoEnter flag, if auto PiP is enabled. */
+  private void applyAutoPipParams(boolean autoEnterEnabled) {
+    if (!autoPipEnabled || activity == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
       return;
     }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-      PictureInPictureParams params =
-          new PictureInPictureParams.Builder()
-              .setAspectRatio(getVideoAspectRatio())
-              .setAutoEnterEnabled(true)
-              .build();
-      activity.setPictureInPictureParams(params);
-    }
+    activity.setPictureInPictureParams(
+        new PictureInPictureParams.Builder()
+            .setAspectRatio(getVideoAspectRatio())
+            .setAutoEnterEnabled(autoEnterEnabled)
+            .build());
   }
 
   void dispose() {
+    // End any dedicated PiP session before releasing the player it renders from.
+    PipActivityController.onPlayerDisposed(this);
     activity = null;
     if (isInitialized) {
       exoPlayer.stop();

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -12,6 +12,8 @@ import android.app.PictureInPictureParams;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.net.Uri;
 import android.os.Build;
 import android.util.Rational;
@@ -87,6 +89,7 @@ final class VideoPlayer {
   @Nullable private Activity activity;
   @Nullable private PipRequestHandler pipRequestHandler;
   private boolean autoPipEnabled = false;
+  private boolean disposed = false;
 
   VideoPlayer(
       Context context,
@@ -353,7 +356,7 @@ final class VideoPlayer {
     this.pipRequestHandler = handler;
   }
 
-  void startPictureInPicture() {
+  void startPictureInPicture(@Nullable RectF sourceRectLogical) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       throw new UnsupportedOperationException(
           "Picture-in-Picture requires API level 26 (Android 8.0) or higher.");
@@ -369,7 +372,21 @@ final class VideoPlayer {
 
     // Manual PiP runs in a dedicated activity so the main app stays usable behind the PiP
     // window and the window shows nothing but the video.
-    PipActivityController.launch(activity, this);
+    PipActivityController.launch(activity, this, logicalToPixelRect(sourceRectLogical));
+  }
+
+  /** Converts a rect in Flutter logical pixels to physical pixels. */
+  @Nullable
+  private Rect logicalToPixelRect(@Nullable RectF logical) {
+    if (logical == null || activity == null) {
+      return null;
+    }
+    float density = activity.getResources().getDisplayMetrics().density;
+    return new Rect(
+        Math.round(logical.left * density),
+        Math.round(logical.top * density),
+        Math.round(logical.right * density),
+        Math.round(logical.bottom * density));
   }
 
   /** Redirects video output to the dedicated PiP activity's surface. */
@@ -461,12 +478,7 @@ final class VideoPlayer {
       pipRequestHandler.onPipRequested();
     }
 
-    PictureInPictureParams params =
-        new PictureInPictureParams.Builder()
-            .setAspectRatio(getVideoAspectRatio())
-            .setAutoEnterEnabled(enabled)
-            .build();
-    activity.setPictureInPictureParams(params);
+    applyAutoPipParams(enabled);
 
     sendAutoPipChangedEvent(enabled);
   }
@@ -481,7 +493,9 @@ final class VideoPlayer {
    * autoPipEnabled flag is kept so {@link #updateAutoPipParams()} can restore the params later.
    */
   void suspendAutoEnter() {
-    applyAutoPipParams(false);
+    if (autoPipEnabled) {
+      applyAutoPipParams(false);
+    }
   }
 
   /** Returns the video aspect ratio, defaulting to 16:9 if unavailable. */
@@ -541,12 +555,14 @@ final class VideoPlayer {
 
   /** Re-applies auto PiP params with the current video aspect ratio if enabled. */
   void updateAutoPipParams() {
-    applyAutoPipParams(true);
+    if (autoPipEnabled) {
+      applyAutoPipParams(true);
+    }
   }
 
-  /** Sets host-activity PiP params with the given autoEnter flag, if auto PiP is enabled. */
+  /** Sets host-activity PiP params with the given autoEnter flag. */
   private void applyAutoPipParams(boolean autoEnterEnabled) {
-    if (!autoPipEnabled || activity == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+    if (activity == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
       return;
     }
     activity.setPictureInPictureParams(
@@ -556,7 +572,12 @@ final class VideoPlayer {
             .build());
   }
 
+  boolean isDisposed() {
+    return disposed;
+  }
+
   void dispose() {
+    disposed = true;
     // End any dedicated PiP session before releasing the player it renders from.
     PipActivityController.onPlayerDisposed(this);
     activity = null;

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -64,6 +64,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
                     injector.flutterLoader()::getLookupKeyForAsset,
                     binding.getTextureRegistry());
     flutterState.startListening(this, binding.getBinaryMessenger());
+    PipActivityController.setOnPipEndedListener(this::onDedicatedPipEnded);
   }
 
   @Override
@@ -71,9 +72,25 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
     if (flutterState == null) {
       Log.wtf(TAG, "Detached from the engine before registering to it.");
     }
+    PipActivityController.setOnPipEndedListener(null);
     flutterState.stopListening(binding.getBinaryMessenger());
     flutterState = null;
     onDestroy();
+  }
+
+  // Called when the dedicated PiP activity session ends, however it ended.
+  private void onDedicatedPipEnded(@Nullable VideoPlayer endedPlayer) {
+    // Restore host-activity autoEnter params suspended while the dedicated PiP was showing.
+    for (int i = 0; i < videoPlayers.size(); i++) {
+      videoPlayers.valueAt(i).updateAutoPipParams();
+    }
+    // Mirror the host-activity listener: keep lastPipPlayerId only while auto PiP is enabled.
+    if (endedPlayer == null || endedPlayer.isAutoPipEnabled()) {
+      return;
+    }
+    if (videoPlayers.get(lastPipPlayerId) == endedPlayer) {
+      lastPipPlayerId = -1;
+    }
   }
 
   // -- ActivityAware implementation --
@@ -337,6 +354,11 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
   @Override
   public void startPictureInPicture(TextureMessage arg) {
     VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    // Suspend host-activity auto PiP while the dedicated PiP activity is showing, so leaving
+    // the app cannot create a second PiP window. Restored in onDedicatedPipEnded.
+    for (int i = 0; i < videoPlayers.size(); i++) {
+      videoPlayers.valueAt(i).suspendAutoEnter();
+    }
     player.startPictureInPicture();
   }
 

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -24,6 +24,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
+import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugins.videoplayer.Messages.AndroidVideoPlayerApi;
 import io.flutter.plugins.videoplayer.Messages.BufferMessage;
 import io.flutter.plugins.videoplayer.Messages.CreateMessage;
@@ -51,6 +52,12 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
   // Tracks which player last requested PiP, so events go to the right player.
   private long lastPipPlayerId = -1;
   @Nullable private Consumer<PictureInPictureModeChangedInfo> pipModeChangedListener;
+  // ホスト Activity 離脱直前 (onUserLeaveHint) に auto PiP を発火するリスナ。
+  // Flutter の ActivityPluginBinding が用意する dispatcher で発火するため、
+  // FlutterFragmentActivity が super.onUserLeaveHint を呼ばない構造でも動作する。
+  @Nullable private PluginRegistry.UserLeaveHintListener userLeaveHintListener;
+  // register/unregister を対称にするため binding 参照を保持する。
+  @Nullable private ActivityPluginBinding activityBinding;
 
   /** Register this with the v2 embedding for the plugin to respond to lifecycle callbacks. */
   public VideoPlayerPlugin() {}
@@ -82,11 +89,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
 
   // Called when the dedicated PiP activity session ends, however it ended.
   private void onDedicatedPipEnded(@Nullable VideoPlayer endedPlayer) {
-    // Restore host-activity autoEnter params suspended while the dedicated PiP was showing.
-    for (int i = 0; i < videoPlayers.size(); i++) {
-      videoPlayers.valueAt(i).updateAutoPipParams();
-    }
-    // Mirror the host-activity listener: keep lastPipPlayerId only while auto PiP is enabled.
+    // auto PiP が有効な間は lastPipPlayerId を保持し、次回発火時に同じ player を対象にする。
     if (endedPlayer == null || endedPlayer.isAutoPipEnabled()) {
       return;
     }
@@ -100,12 +103,18 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
     activity = binding.getActivity();
+    Log.i(
+        TAG,
+        "onAttachedToActivity: activity="
+            + (activity != null ? activity.getClass().getName() : "null"));
     setActivityOnAllPlayers(activity);
     registerPipModeChangedListener(binding);
+    registerUserLeaveHintListener(binding);
   }
 
   @Override
   public void onDetachedFromActivityForConfigChanges() {
+    unregisterUserLeaveHintListener();
     activity = null;
     setActivityOnAllPlayers(null);
   }
@@ -115,10 +124,12 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
     activity = binding.getActivity();
     setActivityOnAllPlayers(activity);
     registerPipModeChangedListener(binding);
+    registerUserLeaveHintListener(binding);
   }
 
   @Override
   public void onDetachedFromActivity() {
+    unregisterUserLeaveHintListener();
     activity = null;
     setActivityOnAllPlayers(null);
     pipModeChangedListener = null;
@@ -169,6 +180,51 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
           };
       provider.addOnPictureInPictureModeChangedListener(pipModeChangedListener);
     }
+  }
+
+  // ホスト Activity 離脱直前 (Home / Recents 押下時) に auto PiP を発火させる。
+  // FlutterFragmentActivity は super.onUserLeaveHint を呼ばない (@SuppressWarnings("MissingSuperCall"))
+  // ため androidx.core の OnUserLeaveHintProvider では受信できない。Flutter が独自に用意する
+  // ActivityPluginBinding.addOnUserLeaveHintListener を使うことで確実に受信できる。
+  private void registerUserLeaveHintListener(@NonNull ActivityPluginBinding binding) {
+    // Config change 経由の二重登録を防ぐ。
+    if (activityBinding != null && userLeaveHintListener != null) {
+      activityBinding.removeOnUserLeaveHintListener(userLeaveHintListener);
+    }
+
+    userLeaveHintListener =
+        () -> {
+          Log.i(TAG, "onUserLeaveHint fired; playersCount=" + videoPlayers.size());
+          // 対象は auto PiP が有効かつ再生中、かつまだ PiP に入っていない player。
+          for (int i = 0; i < videoPlayers.size(); i++) {
+            VideoPlayer player = videoPlayers.valueAt(i);
+            Log.i(
+                TAG,
+                "onUserLeaveHint check[" + i + "]: autoPip=" + player.isAutoPipEnabled()
+                    + ", playing=" + player.getIsPlaying()
+                    + ", pipActive=" + player.isPictureInPictureActive());
+            if (player.isAutoPipEnabled()
+                && player.getIsPlaying()
+                && !player.isPictureInPictureActive()) {
+              Log.i(TAG, "onUserLeaveHint: launching PipActivity for auto PiP");
+              // onUserLeaveHint は onPause 直前に呼ばれ Activity はまだ visible。
+              // ここから同期的に startActivity することで Background Activity Start 制限を回避する。
+              player.startPictureInPicture(null);
+              return;
+            }
+          }
+        };
+    binding.addOnUserLeaveHintListener(userLeaveHintListener);
+    activityBinding = binding;
+    Log.i(TAG, "OnUserLeaveHint listener registered via ActivityPluginBinding");
+  }
+
+  private void unregisterUserLeaveHintListener() {
+    if (userLeaveHintListener != null && activityBinding != null) {
+      activityBinding.removeOnUserLeaveHintListener(userLeaveHintListener);
+    }
+    userLeaveHintListener = null;
+    activityBinding = null;
   }
 
   private void disposeAllPlayers() {
@@ -356,11 +412,6 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
   @Override
   public void startPictureInPicture(StartPipMessage arg) {
     VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    // Suspend host-activity auto PiP while the dedicated PiP activity is showing, so leaving
-    // the app cannot create a second PiP window. Restored in onDedicatedPipEnded.
-    for (int i = 0; i < videoPlayers.size(); i++) {
-      videoPlayers.valueAt(i).suspendAutoEnter();
-    }
     player.startPictureInPicture(sourceRectFromMessage(arg));
   }
 

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -8,6 +8,7 @@ import static java.lang.Math.toIntExact;
 
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.RectF;
 import android.os.Build;
 import android.util.LongSparseArray;
 import androidx.annotation.NonNull;
@@ -34,6 +35,7 @@ import io.flutter.plugins.videoplayer.Messages.MixWithOthersMessage;
 import io.flutter.plugins.videoplayer.Messages.PipStatusMessage;
 import io.flutter.plugins.videoplayer.Messages.PlaybackSpeedMessage;
 import io.flutter.plugins.videoplayer.Messages.PositionMessage;
+import io.flutter.plugins.videoplayer.Messages.StartPipMessage;
 import io.flutter.plugins.videoplayer.Messages.TextureMessage;
 import io.flutter.plugins.videoplayer.Messages.VolumeMessage;
 import io.flutter.view.TextureRegistry;
@@ -352,14 +354,32 @@ public class VideoPlayerPlugin implements FlutterPlugin, ActivityAware, AndroidV
   }
 
   @Override
-  public void startPictureInPicture(TextureMessage arg) {
+  public void startPictureInPicture(StartPipMessage arg) {
     VideoPlayer player = videoPlayers.get(arg.getTextureId());
     // Suspend host-activity auto PiP while the dedicated PiP activity is showing, so leaving
     // the app cannot create a second PiP window. Restored in onDedicatedPipEnded.
     for (int i = 0; i < videoPlayers.size(); i++) {
       videoPlayers.valueAt(i).suspendAutoEnter();
     }
-    player.startPictureInPicture();
+    player.startPictureInPicture(sourceRectFromMessage(arg));
+  }
+
+  /** Rect of the video widget in Flutter logical pixels, or null when not provided. */
+  @Nullable
+  private static RectF sourceRectFromMessage(StartPipMessage msg) {
+    if (msg.getSourceRectLeft() == null
+        || msg.getSourceRectTop() == null
+        || msg.getSourceRectWidth() == null
+        || msg.getSourceRectHeight() == null) {
+      return null;
+    }
+    float left = msg.getSourceRectLeft().floatValue();
+    float top = msg.getSourceRectTop().floatValue();
+    return new RectF(
+        left,
+        top,
+        left + msg.getSourceRectWidth().floatValue(),
+        top + msg.getSourceRectHeight().floatValue());
   }
 
   @Override

--- a/packages/video_player/video_player_android/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/video_player/video_player_android/example/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
       android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|screenLayout|locale|layoutDirection"
       android:hardwareAccelerated="true"
       android:name="io.flutter.embedding.android.FlutterFragmentActivity"
-      android:supportsPictureInPicture="true"
       android:theme="@style/LaunchTheme"
       android:windowSoftInputMode="adjustResize">
       <intent-filter>

--- a/packages/video_player/video_player_android/example/lib/main.dart
+++ b/packages/video_player/video_player_android/example/lib/main.dart
@@ -54,34 +54,8 @@ class _AppState extends State<_App> {
     super.dispose();
   }
 
-  /// Returns the controller that is currently in PiP mode, or null.
-  MiniController? get _pipController {
-    if (_assetController.isPipActive) {
-      return _assetController;
-    }
-    if (_remoteController.isPipActive) {
-      return _remoteController;
-    }
-    return null;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final MiniController? pip = _pipController;
-
-    // PiP mode: show only the video, filling the entire window.
-    if (pip != null) {
-      return Scaffold(
-        backgroundColor: Colors.black,
-        body: Center(
-          child: AspectRatio(
-            aspectRatio: pip.value.aspectRatio,
-            child: VideoPlayer(pip),
-          ),
-        ),
-      );
-    }
-
     // Normal mode: tabbed layout with controls.
     return DefaultTabController(
       length: 2,

--- a/packages/video_player/video_player_android/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_android/example/lib/mini_controller.dart
@@ -192,6 +192,11 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
   @visibleForTesting
   int get textureId => _textureId;
 
+  /// Callback that returns the screen rect of the video widget.
+  /// Set automatically by the [VideoPlayer] widget's state; used as the PiP
+  /// enter-animation origin on Android.
+  Rect? Function()? pipSourceRectProvider;
+
   /// Attempts to open the given [dataSource] and load metadata about the video.
   Future<void> initialize() async {
     _creatingCompleter = Completer<void>();
@@ -370,7 +375,14 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
 
   /// Starts Picture-in-Picture mode.
   Future<void> startPictureInPicture() {
-    return _platform.startPictureInPicture(_textureId);
+    final Rect? sourceRect = pipSourceRectProvider?.call();
+    return _platform.startPictureInPicture(
+      _textureId,
+      sourceRectLeft: sourceRect?.left,
+      sourceRectTop: sourceRect?.top,
+      sourceRectWidth: sourceRect?.width,
+      sourceRectHeight: sourceRect?.height,
+    );
   }
 
   /// Stops Picture-in-Picture mode.
@@ -429,6 +441,16 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   late int _textureId;
 
+  Rect? _getSourceRect() {
+    final RenderBox? renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox == null || !renderBox.hasSize) {
+      return null;
+    }
+    final Offset offset = renderBox.localToGlobal(Offset.zero);
+    return Rect.fromLTWH(
+        offset.dx, offset.dy, renderBox.size.width, renderBox.size.height);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -436,20 +458,24 @@ class _VideoPlayerState extends State<VideoPlayer> {
     // Need to listen for initialization events since the actual texture ID
     // becomes available after asynchronous initialization finishes.
     widget.controller.addListener(_listener);
+    widget.controller.pipSourceRectProvider = _getSourceRect;
   }
 
   @override
   void didUpdateWidget(VideoPlayer oldWidget) {
     super.didUpdateWidget(oldWidget);
     oldWidget.controller.removeListener(_listener);
+    oldWidget.controller.pipSourceRectProvider = null;
     _textureId = widget.controller.textureId;
     widget.controller.addListener(_listener);
+    widget.controller.pipSourceRectProvider = _getSourceRect;
   }
 
   @override
   void deactivate() {
     super.deactivate();
     widget.controller.removeListener(_listener);
+    widget.controller.pipSourceRectProvider = null;
   }
 
   @override

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -214,8 +214,20 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
-  Future<void> startPictureInPicture(int textureId) {
-    return _api.startPictureInPicture(TextureMessage(textureId: textureId));
+  Future<void> startPictureInPicture(
+    int textureId, {
+    double? sourceRectLeft,
+    double? sourceRectTop,
+    double? sourceRectWidth,
+    double? sourceRectHeight,
+  }) {
+    return _api.startPictureInPicture(StartPipMessage(
+      textureId: textureId,
+      sourceRectLeft: sourceRectLeft,
+      sourceRectTop: sourceRectTop,
+      sourceRectWidth: sourceRectWidth,
+      sourceRectHeight: sourceRectHeight,
+    ));
   }
 
   @override

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -327,6 +327,43 @@ class PipStatusMessage {
   }
 }
 
+class StartPipMessage {
+  StartPipMessage({
+    required this.textureId,
+    this.sourceRectLeft,
+    this.sourceRectTop,
+    this.sourceRectWidth,
+    this.sourceRectHeight,
+  });
+
+  int textureId;
+  double? sourceRectLeft;
+  double? sourceRectTop;
+  double? sourceRectWidth;
+  double? sourceRectHeight;
+
+  Object encode() {
+    final Map<Object?, Object?> pigeonMap = <Object?, Object?>{};
+    pigeonMap['textureId'] = textureId;
+    pigeonMap['sourceRectLeft'] = sourceRectLeft;
+    pigeonMap['sourceRectTop'] = sourceRectTop;
+    pigeonMap['sourceRectWidth'] = sourceRectWidth;
+    pigeonMap['sourceRectHeight'] = sourceRectHeight;
+    return pigeonMap;
+  }
+
+  static StartPipMessage decode(Object message) {
+    final Map<Object?, Object?> pigeonMap = message as Map<Object?, Object?>;
+    return StartPipMessage(
+      textureId: pigeonMap['textureId']! as int,
+      sourceRectLeft: pigeonMap['sourceRectLeft'] as double?,
+      sourceRectTop: pigeonMap['sourceRectTop'] as double?,
+      sourceRectWidth: pigeonMap['sourceRectWidth'] as double?,
+      sourceRectHeight: pigeonMap['sourceRectHeight'] as double?,
+    );
+  }
+}
+
 class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
   const _AndroidVideoPlayerApiCodec();
   @override
@@ -351,34 +388,38 @@ class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
     } else 
-    if (value is MixWithOthersMessage) {
+    if (value is MaxVideoResolutionMessage) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PlaybackSpeedMessage) {
+    if (value is MixWithOthersMessage) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PositionMessage) {
+    if (value is PipStatusMessage) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else 
-    if (value is TextureMessage) {
+    if (value is PlaybackSpeedMessage) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
     } else 
-    if (value is VolumeMessage) {
+    if (value is PositionMessage) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
     } else 
-    if (value is MaxVideoResolutionMessage) {
+    if (value is StartPipMessage) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else
-    if (value is PipStatusMessage) {
+    } else 
+    if (value is TextureMessage) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else
+    } else 
+    if (value is VolumeMessage) {
+      buffer.putUint8(140);
+      writeValue(buffer, value.encode());
+    } else 
 {
       super.writeValue(buffer, value);
     }
@@ -402,27 +443,30 @@ class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
         return LoopingMessage.decode(readValue(buffer)!);
       
       case 133:       
-        return MixWithOthersMessage.decode(readValue(buffer)!);
+        return MaxVideoResolutionMessage.decode(readValue(buffer)!);
       
       case 134:       
-        return PlaybackSpeedMessage.decode(readValue(buffer)!);
+        return MixWithOthersMessage.decode(readValue(buffer)!);
       
       case 135:       
-        return PositionMessage.decode(readValue(buffer)!);
+        return PipStatusMessage.decode(readValue(buffer)!);
       
       case 136:       
-        return TextureMessage.decode(readValue(buffer)!);
+        return PlaybackSpeedMessage.decode(readValue(buffer)!);
       
       case 137:       
+        return PositionMessage.decode(readValue(buffer)!);
+      
+      case 138:       
+        return StartPipMessage.decode(readValue(buffer)!);
+      
+      case 139:       
+        return TextureMessage.decode(readValue(buffer)!);
+      
+      case 140:       
         return VolumeMessage.decode(readValue(buffer)!);
       
-      case 138:
-        return MaxVideoResolutionMessage.decode(readValue(buffer)!);
-
-      case 139:
-        return PipStatusMessage.decode(readValue(buffer)!);
-
-      default:
+      default:      
         return super.readValueOfType(type, buffer);
       
     }
@@ -789,7 +833,7 @@ class AndroidVideoPlayerApi {
     }
   }
 
-  Future<void> startPictureInPicture(TextureMessage arg_msg) async {
+  Future<void> startPictureInPicture(StartPipMessage arg_msg) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.AndroidVideoPlayerApi.startPictureInPicture', codec, binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -88,6 +88,20 @@ class PipStatusMessage {
   bool value;
 }
 
+class StartPipMessage {
+  StartPipMessage(this.textureId, this.sourceRectLeft, this.sourceRectTop,
+      this.sourceRectWidth, this.sourceRectHeight);
+  int textureId;
+
+  /// Screen rect of the video widget in logical pixels, used as the origin of
+  /// the PiP enter animation (sourceRectHint). All null when unknown, in which
+  /// case the system animates from the full screen.
+  double? sourceRectLeft;
+  double? sourceRectTop;
+  double? sourceRectWidth;
+  double? sourceRectHeight;
+}
+
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')
 abstract class AndroidVideoPlayerApi {
   void initialize();
@@ -105,7 +119,7 @@ abstract class AndroidVideoPlayerApi {
   void setBuffer(BufferMessage msg);
   void setMaxVideoResolution(MaxVideoResolutionMessage msg);
   IsPlayingMessage isPlaying(TextureMessage msg);
-  void startPictureInPicture(TextureMessage msg);
+  void startPictureInPicture(StartPipMessage msg);
   void stopPictureInPicture(TextureMessage msg);
   PipStatusMessage isPictureInPictureSupported(TextureMessage msg);
   PipStatusMessage isPictureInPictureActive(TextureMessage msg);

--- a/packages/video_player/video_player_android/test/test_api.dart
+++ b/packages/video_player/video_player_android/test/test_api.dart
@@ -22,10 +22,6 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
       buffer.putUint8(128);
       writeValue(buffer, value.encode());
     } else 
-    if (value is MaxVideoResolutionMessage) {
-      buffer.putUint8(138);
-      writeValue(buffer, value.encode());
-    } else 
     if (value is CreateMessage) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
@@ -42,24 +38,36 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
     } else 
-    if (value is MixWithOthersMessage) {
+    if (value is MaxVideoResolutionMessage) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PlaybackSpeedMessage) {
+    if (value is MixWithOthersMessage) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else 
-    if (value is PositionMessage) {
+    if (value is PipStatusMessage) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else 
-    if (value is TextureMessage) {
+    if (value is PlaybackSpeedMessage) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
     } else 
-    if (value is VolumeMessage) {
+    if (value is PositionMessage) {
       buffer.putUint8(137);
+      writeValue(buffer, value.encode());
+    } else 
+    if (value is StartPipMessage) {
+      buffer.putUint8(138);
+      writeValue(buffer, value.encode());
+    } else 
+    if (value is TextureMessage) {
+      buffer.putUint8(139);
+      writeValue(buffer, value.encode());
+    } else 
+    if (value is VolumeMessage) {
+      buffer.putUint8(140);
       writeValue(buffer, value.encode());
     } else 
 {
@@ -71,9 +79,6 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
     switch (type) {
       case 128:       
         return BufferMessage.decode(readValue(buffer)!);
-      
-      case 138:       
-        return MaxVideoResolutionMessage.decode(readValue(buffer)!);
       
       case 129:       
         return CreateMessage.decode(readValue(buffer)!);
@@ -88,18 +93,27 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
         return LoopingMessage.decode(readValue(buffer)!);
       
       case 133:       
-        return MixWithOthersMessage.decode(readValue(buffer)!);
+        return MaxVideoResolutionMessage.decode(readValue(buffer)!);
       
       case 134:       
-        return PlaybackSpeedMessage.decode(readValue(buffer)!);
+        return MixWithOthersMessage.decode(readValue(buffer)!);
       
       case 135:       
-        return PositionMessage.decode(readValue(buffer)!);
+        return PipStatusMessage.decode(readValue(buffer)!);
       
       case 136:       
-        return TextureMessage.decode(readValue(buffer)!);
+        return PlaybackSpeedMessage.decode(readValue(buffer)!);
       
       case 137:       
+        return PositionMessage.decode(readValue(buffer)!);
+      
+      case 138:       
+        return StartPipMessage.decode(readValue(buffer)!);
+      
+      case 139:       
+        return TextureMessage.decode(readValue(buffer)!);
+      
+      case 140:       
         return VolumeMessage.decode(readValue(buffer)!);
       
       default:      
@@ -126,7 +140,7 @@ abstract class TestHostVideoPlayerApi {
   void setBuffer(BufferMessage msg);
   void setMaxVideoResolution(MaxVideoResolutionMessage msg);
   IsPlayingMessage isPlaying(TextureMessage msg);
-  void startPictureInPicture(TextureMessage msg);
+  void startPictureInPicture(StartPipMessage msg);
   void stopPictureInPicture(TextureMessage msg);
   PipStatusMessage isPictureInPictureSupported(TextureMessage msg);
   PipStatusMessage isPictureInPictureActive(TextureMessage msg);
@@ -378,8 +392,8 @@ abstract class TestHostVideoPlayerApi {
         channel.setMockMessageHandler((Object? message) async {
           assert(message != null, 'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.startPictureInPicture was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final TextureMessage? arg_msg = (args[0] as TextureMessage?);
-          assert(arg_msg != null, 'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.startPictureInPicture was null, expected non-null TextureMessage.');
+          final StartPipMessage? arg_msg = (args[0] as StartPipMessage?);
+          assert(arg_msg != null, 'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.startPictureInPicture was null, expected non-null StartPipMessage.');
           api.startPictureInPicture(arg_msg!);
           return <Object?, Object?>{};
         });

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -216,7 +216,14 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
-  Future<void> startPictureInPicture(int textureId) {
+  Future<void> startPictureInPicture(
+    int textureId, {
+    double? sourceRectLeft,
+    double? sourceRectTop,
+    double? sourceRectWidth,
+    double? sourceRectHeight,
+  }) {
+    // iOS animates from the AVPlayerLayer itself; the source rect is unused.
     return _api.startPictureInPicture(TextureMessage(textureId: textureId));
   }
 

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -125,7 +125,18 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
   }
 
   /// Starts Picture-in-Picture mode.
-  Future<void> startPictureInPicture(int textureId) {
+  ///
+  /// The optional source rect describes the screen position of the video
+  /// widget in logical pixels. On Android it is used as the origin of the
+  /// PiP enter animation (sourceRectHint) so the window animates out of the
+  /// video instead of the full screen. Ignored on other platforms.
+  Future<void> startPictureInPicture(
+    int textureId, {
+    double? sourceRectLeft,
+    double? sourceRectTop,
+    double? sourceRectWidth,
+    double? sourceRectHeight,
+  }) {
     throw UnimplementedError(
         'startPictureInPicture() has not been implemented.');
   }


### PR DESCRIPTION
## 概要

Android の手動 PiP を、MainActivity（Flutter ホスト Activity）全体を PiP 化する方式から、動画 surface だけを持つ専用ネイティブ Activity（`PipActivity`）を PiP 化する方式に変更します。

- PiP ウィンドウには動画のみが表示される（Flutter UI の映り込みなし）
- **PiP 中もアプリ本体をフル画面で操作できる**（iOS の AVPictureInPictureController と同等の挙動になり、プラットフォーム間のパリティが取れる）

## 実装

- **API 33+**: `ActivityOptions.makeLaunchIntoPip()` で最初から PiP 状態で起動（フルスクリーン表示のチラつきなし）
- **API 26–32**: 起動直後に `onCreate`（フォールバック: `onWindowFocusChanged`）で `enterPictureInPictureMode()`。一瞬の全画面表示は黒テーマ + アスペクト比レターボックスで緩和
- ExoPlayer の出力 surface を Flutter texture ⇄ PipActivity の SurfaceView で動的に切替（`attachPipSurface` / `restoreFlutterSurface`）
- PipActivity はホストと同一タスクに積むため、PiP ウィンドウ展開時は `finish()` するだけで MainActivity に戻る
- PiP ウィンドウを × で閉じた場合のみ `pause()`（展開・Stop PiP では再生継続）
- **auto PiP（ホームスワイプ）は従来どおり MainActivity 方式のまま**（ハイブリッド運用）。手動 PiP 表示中は `autoEnterEnabled` を一時無効化し、二重 PiP を防止
- Dart 側 API・イベント契約（`pipStarted` / `pipStopped` 等）は変更なし
- `PipActivity` はプラグインの AndroidManifest で宣言しており、**利用アプリ側のマニフェスト変更は不要**
- example: PiP 中に「黒背景 + 動画のみ」へ切り替える旧レイアウト分岐を削除（新方式では PiP 中も本体 UI が見えるため、この分岐が本体画面を真っ黒にしてしまう）

## 制約・仕様

- PiP 中、Flutter 側の動画ウィジェットは最終フレームで固定表示になる（MediaCodec は出力 surface を 1 つしか持てないため）。必要ならアプリ側で `isPipActive` 中にプレースホルダーを被せる
- デバッグログはタグ `VideoPlayerPip` で出力

## 動作確認

- [x] `:video_player_android:compileDebugJavaWithJavac` BUILD SUCCESSFUL
- [x] example アプリのマージ済みマニフェストに `PipActivity` が含まれることを確認
- [ ] 実機: API 33+ でのチラつきなし PiP 起動 / PiP 中の本体操作 / 3 つの復帰経路（展開・×・Stop PiP）/ auto PiP との共存
- ユニットテスト（`testDebugUnitTest`）はベースブランチ既存の minSdk 16 vs androidx.window:1.2.0 の manifest merge 問題で実行不可（本変更とは無関係。変更前でも同様に失敗することを確認済み）
